### PR TITLE
Updated formatting for rules section; terminology adjustment

### DIFF
--- a/docs/combat/actions_in_combat.md
+++ b/docs/combat/actions_in_combat.md
@@ -1,40 +1,48 @@
-# Actions in Combat 
+# Actions in Combat
 When you take your action on your turn, you can take one of the actions presented here, an action you gained from your class or a special feature, or an action that you improvise. Many monsters have action options of their own in their stat blocks.    
-When you describe an action not detailed elsewhere in the rules, the GM tells you whether that action is possible and what kind of roll you need to make, if any, to determine success or failure. 
 
-## Attack 
+When you describe an action not detailed elsewhere in the rules, the GM tells you whether that action is possible and what kind of roll you need to make, if any, to determine success or failure.
+
+## Attack
 The most common action to take in combat is the Attack action, whether you are swinging a sword, firing an arrow from a bow, or brawling with your fists.    
+
 With this action, you make one melee or ranged attack. See the "Making an Attack" section for the rules that govern attacks.    
-Certain features, such as the Extra Attack feature of the fighter, allow you to make more than one attack with this action. 
 
-## Cast a Spell 
-Spellcasters such as wizards and clerics, as well as many monsters, have access to spells and can use them to great effect in combat. Each spell has a casting time, which specifies whether the caster must use an action, a reaction, minutes, or even hours to cast the spell. Casting a spell is, therefore, not necessarily an action. Most spells do have a casting time of 1 action, so a spellcaster often uses his or her action in combat to cast such a spell. 
+Certain features, such as the Extra Attack feature of the fighter, allow you to make more than one attack with this action.
 
-## Dash 
+## Cast a Spell
+Spellcasters such as wizards and clerics, as well as many monsters, have access to spells and can use them to great effect in combat. Each spell has a casting time, which specifies whether the caster must use an action, a reaction, minutes, or even hours to cast the spell. Casting a spell is, therefore, not necessarily an action. Most spells do have a casting time of 1 action, so a spellcaster often uses his or her action in combat to cast such a spell.
+
+## Dash
 When you take the Dash action, you gain extra movement for the current turn. The increase equals your speed, after applying any modifiers. With a speed of 30 feet, for example, you can move up to 60 feet on your turn if you dash.    
-Any increase or decrease to your speed changes this additional movement by the same amount. If your speed of 30 feet is reduced to 15 feet, for instance, you can move up to 30 feet this turn if you dash. 
 
-## Disengage 
-If you take the Disengage action, your movement doesn't provoke opportunity attacks for the rest of the turn. 
+Any increase or decrease to your speed changes this additional movement by the same amount. If your speed of 30 feet is reduced to 15 feet, for instance, you can move up to 30 feet this turn if you dash.
 
-## Dodge 
-When you take the Dodge action, you focus entirely on avoiding attacks. Until the start of your next turn, any attack roll made against you has disadvantage if you can see the attacker, and you make Dexterity saving throws with advantage. You lose this benefit if you are incapacitated or if your speed drops to 0. 
+## Disengage
+If you take the Disengage action, your movement doesn't provoke opportunity attacks for the rest of the turn.
 
-## Help 
+## Dodge
+When you take the Dodge action, you focus entirely on avoiding attacks. Until the start of your next turn, any attack roll made against you has disadvantage if you can see the attacker, and you make Dexterity saving throws with advantage. You lose this benefit if you are incapacitated or if your speed drops to 0.
+
+## Help
 You can lend your aid to another creature in the completion of a task. When you take the Help action, the creature you aid gains advantage on the next ability check it makes to perform the task you are helping with, provided that it makes the check before the start of your next turn.    
-Alternatively, you can aid a friendly creature in attacking a creature within 5 feet of you. You feint, distract the target, or in some other way team up to make your ally's attack more effective. If your ally attacks the target before your next turn, the first attack roll is made with advantage. 
 
-## Hide 
+Alternatively, you can aid a friendly creature in attacking a creature within 5 feet of you. You feint, distract the target, or in some other way team up to make your ally's attack more effective. If your ally attacks the target before your next turn, the first attack roll is made with advantage.
+
+## Hide
 When you take the Hide action, you make a Dexterity (Stealth) check in an attempt to hide, following the rules for hiding. If you succeed, you gain certain benefits, as described in the "Unseen Attackers and Targets" section later in this chapter.    
 
-## Ready 
+## Ready
 Sometimes you want to get the jump on a foe or wait for a particular circumstance before you act. To do so, you can take the Ready action on your turn, which lets you act using your reaction before the start of your next turn.   
+
 First, you decide what perceivable circumstance will trigger your reaction. Then, you choose the action you will take in response to that trigger, or you choose to move up to your speed in response to it. Examples include "If the cultist steps on the trapdoor, I'll pull the lever that opens it," and "If the goblin steps next to me, I move away."    
+
 When the trigger occurs, you can either take your reaction right after the trigger finishes or ignore the trigger. Remember that you can take only one reaction per round.    
-When you ready a spell, you cast it as normal but hold its energy, which you release with your reaction when the trigger occurs. To be readied, a spell must have a casting time of 1 action, and holding onto the spell's magic requires concentration. If your concentration is broken, the spell dissipates without taking effect. For example, if you are concentrating on the **_web_** spell and ready **_magic missile_**, your **_web_** spell ends, and if you take damage before you release **_magic missile_** with your reaction, your concentration might be broken. 
 
-## Search 
-When you take the Search action, you devote your attention to finding something. Depending on the nature of your search, the GM might have you make a Wisdom (Perception) check or an Intelligence (Investigation) check. 
+When you ready a spell, you cast it as normal but hold its energy, which you release with your reaction when the trigger occurs. To be readied, a spell must have a casting time of 1 action, and holding onto the spell's magic requires concentration. If your concentration is broken, the spell dissipates without taking effect. For example, if you are concentrating on the **_web_** spell and ready **_magic missile_**, your **_web_** spell ends, and if you take damage before you release **_magic missile_** with your reaction, your concentration might be broken.
 
-## Use an Object 
+## Search
+When you take the Search action, you devote your attention to finding something. Depending on the nature of your search, the GM might have you make a Wisdom (Perception) check or an Intelligence (Investigation) check.
+
+## Use an Object
 You normally interact with an object while doing something else, such as when you draw a sword as part of an attack. When an object requires your action for its use, you take the Use an Object action. This action is also useful when you want to interact with more than one object on your turn.

--- a/docs/combat/cover.md
+++ b/docs/combat/cover.md
@@ -1,6 +1,13 @@
-# Cover 
-Walls, trees, creatures, and other obstacles can provide cover during combat, making a target more difficult to harm. A target can benefit from cover only when an attack or other effect originates on the opposite side of the cover.       
+# Cover
+Walls, trees, creatures, and other obstacles can provide cover during combat, making a target more difficult to harm. A target can benefit from cover only when an attack or other effect originates on the opposite side of the cover.      
+
 There are three degrees of cover. If a target is behind multiple sources of cover, only the most protective degree of cover applies; the degrees aren't added together. For example, if a target is behind a creature that gives half cover and a tree trunk that gives three-quarters cover, the target has three-quarters cover.    
+
+#### Half Cover
 A target with **half cover** has a +2 bonus to AC and Dexterity saving throws. A target has half cover if an obstacle blocks at least half of its body. The obstacle might be a low wall, a large piece of furniture, a narrow tree trunk, or a creature, whether that creature is an enemy or a friend.    
+
+#### Three-Quarters Cover
 A target with **three-quarters** cover has a +5 bonus to AC and Dexterity saving throws. A target has three-quarters cover if about three-quarters of it is covered by an obstacle. The obstacle might be a portcullis, an arrow slit, or a thick tree trunk.    
+
+#### Total Cover
 A target with **total cover** can't be targeted directly by an attack or a spell, although some spells can reach such a target by including it in an area of effect. A target has total cover if it is completely concealed by an obstacle.

--- a/docs/combat/damage_and_healing.md
+++ b/docs/combat/damage_and_healing.md
@@ -1,80 +1,109 @@
-# Damage and Healing 
-Injury and the risk of death are constant companions of those who explore fantasy gaming worlds. The thrust of a sword, a well-placed arrow, or a blast of flame from a **_fireball_** spell all have the potential to damage, or even kill, the hardiest of creatures. 
+# Damage and Healing
+Injury and the risk of death are constant companions of those who explore fantasy gaming worlds. The thrust of a sword, a well-placed arrow, or a blast of flame from a **_fireball_** spell all have the potential to damage, or even kill, the hardiest of creatures.
 
-## Hit Points 
+## Hit Points
 Hit points represent a combination of physical and mental durability, the will to live, and luck. Creatures with more hit points are more difficult to kill. Those with fewer hit points are more fragile.    
-A creature's current hit points (usually just called hit points) can be any number from the creature's hit point maximum down to 0. This number changes frequently as a creature takes damage or receives healing.    
-Whenever a creature takes damage, that damage is subtracted from its hit points. The loss of hit points has no effect on a creature's capabilities until the creature drops to 0 hit points. 
 
-## Damage Rolls 
+A creature's current hit points (usually just called hit points) can be any number from the creature's hit point maximum down to 0. This number changes frequently as a creature takes damage or receives healing.   
+
+Whenever a creature takes damage, that damage is subtracted from its hit points. The loss of hit points has no effect on a creature's capabilities until the creature drops to 0 hit points.
+
+## Damage Rolls
 Each weapon, spell, and harmful monster ability specifies the damage it deals. You roll the damage die or dice, add any modifiers, and apply the damage to your target. Magic weapons, special abilities, and other factors can grant a bonus to damage. With a penalty, it is possible to deal 0 damage, but never negative damage.    
+
 When attacking with a **weapon**, you add your ability modifier--the same modifier used for the attack roll--to the damage. A **spell** tells you which dice to roll for damage and whether to add any modifiers.    
-If a spell or other effect deals damage to **more than one target** at the same time, roll the damage once for all of them. For example, when a wizard casts **_fireball_** or a cleric casts **_flame strike_**, the spell's damage is rolled once for all creatures caught in the blast. 
 
-### Critical Hits 
+If a spell or other effect deals damage to **more than one target** at the same time, roll the damage once for all of them. For example, when a wizard casts **_fireball_** or a cleric casts **_flame strike_**, the spell's damage is rolled once for all creatures caught in the blast.
+
+### Critical Hits
 When you score a critical hit, you get to roll extra dice for the attack's damage against the target. Roll all of the attack's damage dice twice and add them together. Then add any relevant modifiers as normal. To speed up play, you can roll all the damage dice at once.    
-For example, if you score a critical hit with a dagger, roll 2d4 for the damage, rather than 1d4, and then add your relevant ability modifier. If the attack involves other damage dice, such as from the rogue's Sneak Attack feature, you roll those dice twice as well. 
 
-### Damage Types 
+For example, if you score a critical hit with a dagger, roll 2d4 for the damage, rather than 1d4, and then add your relevant ability modifier. If the attack involves other damage dice, such as from the rogue's Sneak Attack feature, you roll those dice twice as well.
+
+### Damage Types
 Different attacks, damaging spells, and other harmful effects deal different types of damage. Damage types have no rules of their own, but other rules, such as damage resistance, rely on the types.    
-The damage types follow, with examples to help a GM assign a damage type to a new effect.    
-**Acid.** The corrosive spray of a black dragon's breath and the dissolving enzymes secreted by a black pudding deal acid damage.    
-**Bludgeoning.** Blunt force attacks--hammers, falling, constriction, and the like--deal bludgeoning damage.   
-**Cold.** The infernal chill radiating from an ice devil's spear and the frigid blast of a white dragon's breath deal cold damage.   
-**Fire.** Red dragons breathe fire, and many spells conjure flames to deal fire damage.   
-**Force.** Force is pure magical energy focused into a damaging form. Most effects that deal force damage are spells, including **_magic missile_** and **_spiritual weapon_**.   
-**Lightning.** A **_lightning bolt_** spell and a blue dragon's breath deal lightning damage.   
-**Necrotic.** Necrotic damage, dealt by certain undead and a spell such as **_chill touch_**, withers matter and even the soul.   
-**Piercing.** Puncturing and impaling attacks, including spears and monsters' bites, deal piercing damage.    
-**Poison.** Venomous stings and the toxic gas of a green dragon's breath deal poison damage.    
-**Psychic.** Mental abilities such as a mind flayer's psionic blast deal psychic damage.   
-**Radiant.** Radiant damage, dealt by a cleric's **_flame strike_** spell or an angel's smiting weapon, sears the flesh like fire and overloads the spirit with power.   
-**Slashing.** Swords, axes, and monsters' claws deal slashing damage.   
-**Thunder.** A concussive burst of sound, such as the effect of the **_thunderwave spell_**, deals thunder damage. 
 
-## Damage Resistance and Vulnerability 
+The damage types follow, with examples to help a GM assign a damage type to a new effect.    
+
+| Damage Type | Description |
+|-------------|--|
+|**Bludgeoning** | Blunt force attacks--hammers, falling, constriction, and the like--deal bludgeoning damage.   |
+|**Piercing** | Puncturing and impaling attacks, including spears and monsters' bites, deal piercing damage.   |
+|**Slashing** | Swords, axes, and monsters' claws deal slashing damage.   |
+|**Acid** | The corrosive spray of a black dragon's breath and the dissolving enzymes secreted by a black pudding deal acid damage. |
+|**Cold** | The infernal chill radiating from an ice devil's spear and the frigid blast of a white dragon's breath deal cold damage.   |
+|**Fire** | Red dragons breathe fire, and many spells conjure flames to deal fire damage.   |
+|**Force** | Force is pure magical energy focused into a damaging form. Most effects that deal force damage are spells, including **_magic missile_ ** and **_spiritual weapon_**.   |
+|**Lightning** | A **_lightning bolt_** spell and a blue dragon's breath deal lightning damage.  |
+|**Necrotic** | Necrotic damage, dealt by certain undead and a spell such as **_chill touch_**, withers matter and even the soul.   |
+|**Poison** | Venomous stings and the toxic gas of a green dragon's breath deal poison damage.    |
+|**Psychic** | Mental abilities such as a mind flayer's psionic blast deal psychic damage. |  
+|**Radiant** | Radiant damage, dealt by a cleric's **_flame strike_** spell or an angel's smiting weapon, sears the flesh like fire and overloads the spirit with power.   |
+|**Thunder** | A concussive burst of sound, such as the effect of the **_thunderwave spell_**, deals thunder damage. |
+
+## Damage Resistance and Vulnerability
 Some creatures and objects are exceedingly difficult or unusually easy to hurt with certain types of damage.   
 If a creature or an object has **resistance** to a damage type, damage of that type is halved against it. If a creature or an object has **vulnerability** to a damage type, damage of that type is doubled against it.   
+
 Resistance and then vulnerability are applied after all other modifiers to damage. For example, a creature has resistance to bludgeoning damage and is hit by an attack that deals 25 bludgeoning damage. The creature is also within a magical aura that reduces all damage by 5. The 25 damage is first reduced by 5 and then halved, so the creature takes 10 damage.    
-Multiple instances of resistance or vulnerability that affect the same damage type count as only one instance. For example, if a creature has resistance to fire damage as well as resistance to all nonmagical damage, the damage of a nonmagical fire is reduced by half against the creature, not reduced by three-quarters. 
 
-## Healing 
+Multiple instances of resistance or vulnerability that affect the same damage type count as only one instance. For example, if a creature has resistance to fire damage as well as resistance to all nonmagical damage, the damage of a nonmagical fire is reduced by half against the creature, not reduced by three-quarters.
+
+## Healing
 Unless it results in death, damage isn't permanent. Even death is reversible through powerful magic. Rest can restore a creature's hit points, and magical methods such as a **_cure wounds_** spell or a **potion of healing** can remove damage in an instant.    
-When a creature receives healing of any kind, hit points regained are added to its current hit points. A creature's hit points can't exceed its hit point maximum, so any hit points regained in excess of this number are lost. For example, a druid grants a ranger 8 hit points of healing. If the ranger has 14 current hit points and has a hit point maximum of 20, the ranger regains 6 hit points from the druid, not 8.    
-A creature that has died can't regain hit points until magic such as the **_revivify_** spell has restored it to life. 
 
-## Dropping to 0 Hit Points 
+When a creature receives healing of any kind, hit points regained are added to its current hit points. A creature's hit points can't exceed its hit point maximum, so any hit points regained in excess of this number are lost. For example, a druid grants a ranger 8 hit points of healing. If the ranger has 14 current hit points and has a hit point maximum of 20, the ranger regains 6 hit points from the druid, not 8.   
+
+A creature that has died can't regain hit points until magic such as the **_revivify_** spell has restored it to life.
+
+## Dropping to 0 Hit Points
 When you drop to 0 hit points, you either die outright or fall unconscious, as explained in the following sections.
 
-### Instant Death 
-Massive damage can kill you instantly. When damage reduces you to 0 hit points and there is damage remaining, you die if the remaining damage equals or exceeds your hit point maximum.    
-For example, a cleric with a maximum of 12 hit points currently has 6 hit points. If she takes 18 damage from an attack, she is reduced to 0 hit points, but 12 damage remains. Because the remaining damage equals her hit point maximum, the cleric dies. 
+### Instant Death
+Massive damage can kill you instantly. When damage reduces you to 0 hit points and there is damage remaining, you die if the remaining damage equals or exceeds your hit point maximum.
 
-### Falling Unconscious 
-If damage reduces you to 0 hit points and fails to kill you, you fall unconscious. This unconsciousness ends if you regain any hit points. 
+For example, a cleric with a maximum of 12 hit points currently has 6 hit points. If she takes 18 damage from an attack, she is reduced to 0 hit points, but 12 damage remains. Because the remaining damage equals her hit point maximum, the cleric dies.
 
-### Death Saving Throws 
-Whenever you start your turn with 0 hit points, you must make a special saving throw, called a death saving throw, to determine whether you creep closer to death or hang onto life. Unlike other saving throws, this one isn't tied to any ability score. You are in the hands of fate now, aided only by spells and features that improve your chances of succeeding on a saving throw.    
-Roll a d20. If the roll is 10 or higher, you succeed. Otherwise, you fail. A success or failure has no effect by itself. On your third success, you become stable (see below). On your third failure, you die. The successes and failures don't need to be consecutive; keep track of both until you collect three of a kind. The number of both is reset to zero when you regain any hit points or become stable.    
-**Rolling 1 or 20.** When you make a death saving throw and roll a 1 on the d20, it counts as two failures. If you roll a 20 on the d20, you regain 1 hit point.    
-**Damage at 0 Hit Points.** If you take any damage while you have 0 hit points, you suffer a death saving throw failure. If the damage is from a critical hit, you suffer two failures instead. If the damage equals or exceeds your hit point maximum, you suffer instant death. 
+### Falling Unconscious
+If damage reduces you to 0 hit points and fails to kill you, you fall unconscious. This unconsciousness ends if you regain any hit points.
 
-### Stabilizing a Creature 
-The best way to save a creature with 0 hit points is to heal it. If healing is unavailable, the creature can at least be stabilized so that it isn't killed by a failed death saving throw.    
+### Death Saving Throws
+Whenever you start your turn with 0 hit points, you must make a special saving throw, called a death saving throw, to determine whether you creep closer to death or hang onto life. Unlike other saving throws, this one isn't tied to any ability score. You are in the hands of fate now, aided only by spells and features that improve your chances of succeeding on a saving throw.   
+
+Roll a d20 and consult the table below to determine whether the result is a success or failure. A single success or failure has no effect by itself. On your third success, you become stable (see below). On your third failure, you die. The successes and failures don't need to be consecutive; keep track of both until you collect three of a kind. The number of both is reset to zero when you regain any hit points or become stable.    
+
+If you take any damage while you have 0 hit points, you suffer a death saving throw failure. If the damage is from a critical hit, you suffer two failures instead. If the damage equals or exceeds your hit point maximum, you suffer instant death.
+
+| Roll | Result |
+|------|--------|
+| 1    | Two Failures |
+| 2 - 9 | One Failure |
+| 10 - 19 | One Success |
+| 20 | Automatically become stable, regain 1 HP |
+
+
+
+### Stabilizing a Creature
+The best way to save a creature with 0 hit points is to heal it. If healing is unavailable, the creature can at least be stabilized so that it isn't killed by a failed death saving throw.   
+
 You can use your action to administer first aid to an unconscious creature and attempt to stabilize it, which requires a successful DC 10 Wisdom (Medicine) check.    
-A **stable** creature doesn't make death saving throws, even though it has 0 hit points, but it does remain unconscious. The creature stops being stable, and must start making death saving throws again, if it takes any damage. A stable creature that isn't healed regains 1 hit point after 1d4 hours. 
 
-### Monsters and Death 
-Most GMs have a monster die the instant it drops to 0 hit points, rather than having it fall unconscious and make death saving throws.    
-Mighty villains and special nonplayer characters are common exceptions; the GM might have them fall unconscious and follow the same rules as player characters. 
+A **stable** creature doesn't make death saving throws, even though it has 0 hit points, but it does remain unconscious. The creature stops being stable, and must start making death saving throws again, if it takes any damage. A stable creature that isn't healed regains 1 hit point after 1d4 hours.
 
-## Knocking a Creature Out 
-Sometimes an attacker wants to incapacitate a foe, rather than deal a killing blow. When an attacker reduces a creature to 0 hit points with a melee attack, the attacker can knock the creature out. The attacker can make this choice the instant the damage is dealt. The creature falls unconscious and is stable. 
+### Monsters and Death
+Most GMs have a monster die the instant it drops to 0 hit points, rather than having it fall unconscious and make death saving throws. Mighty villains and special nonplayer characters are common exceptions; the GM might have them fall unconscious and follow the same rules as player characters.
 
-## Temporary Hit Points 
+## Knocking a Creature Out
+Sometimes an attacker wants to incapacitate a foe, rather than deal a killing blow. When an attacker reduces a creature to 0 hit points with a melee attack, the attacker can knock the creature out. The attacker can make this choice the instant the damage is dealt. The creature falls unconscious and is stable.
+
+## Temporary Hit Points
 Some spells and special abilities confer temporary hit points to a creature. Temporary hit points aren't actual hit points; they are a buffer against damage, a pool of hit points that protect you from injury.    
+
 When you have temporary hit points and take damage, the temporary hit points are lost first, and any leftover damage carries over to your normal hit points. For example, if you have 5 temporary hit points and take 7 damage, you lose the temporary hit points and then take 2 damage.    
+
 Because temporary hit points are separate from your actual hit points, they can exceed your hit point maximum. A character can, therefore, be at full hit points and receive temporary hit points.    
+
 Healing can't restore temporary hit points, and they can't be added together. If you have temporary hit points and receive more of them, you decide whether to keep the ones you have or to gain the new ones. For example, if a spell grants you 12 temporary hit points when you already have 10, you can have 12 or 10, not 22.    
+
 If you have 0 hit points, receiving temporary hit points doesn't restore you to consciousness or stabilize you. They can still absorb damage directed at you while you're in that state, but only true healing can save you.    
 Unless a feature that grants you temporary hit points has a duration, they last until they're depleted or you finish a long rest.

--- a/docs/rules/abilities/ability_checks.md
+++ b/docs/rules/abilities/ability_checks.md
@@ -1,10 +1,11 @@
-# Ability Checks 
+# Ability Checks
 An ability check tests a character's or monster's innate talent and training in an effort to overcome a challenge. The GM calls for an ability check when a character or monster attempts an action (other than an attack) that has a chance of failure. When the outcome is uncertain, the dice determine the results.    
+
 For every ability check, the GM decides which of the six abilities is relevant to the task at hand and the difficulty of the task, represented by a Difficulty Class. The more difficult a task, the higher its DC. The Typical Difficulty Classes table shows the most common DCs.
 
 #### Typical Difficulty Classes
 | Task Difficulty   | DC |
-|-------------------|----| 
+|-------------------|----|
 | Very easy         | 5  |
 | Easy              | 10 |
 | Medium            | 15 |
@@ -14,65 +15,70 @@ For every ability check, the GM decides which of the six abilities is relevant t
 
 To make an ability check, roll a d20 and add the relevant ability modifier. As with other d20 rolls, apply bonuses and penalties, and compare the total to the DC. If the total equals or exceeds the DC, the ability check is a success--the creature overcomes the challenge at hand. Otherwise, it's a failure, which means the character or monster makes no progress toward the objective or makes progress combined with a setback determined by the GM.
 
-## Contests 
+## Contests
 Sometimes one character's or monster's efforts are directly opposed to another's. This can occur when both of them are trying to do the same thing and only one can succeed, such as attempting to snatch up a magic ring that has fallen on the floor. This situation also applies when one of them is trying to prevent the other one from accomplishing a goal--for example, when a monster tries to force open a door that an adventurer is holding closed. In situations like these, the outcome is determined by a special form of ability check, called a contest.   
+
 Both participants in a contest make ability checks appropriate to their efforts. They apply all appropriate bonuses and penalties, but instead of comparing the total to a DC, they compare the totals of their two checks. The participant with the higher check total wins the contest. That character or monster either succeeds at the action or prevents the other one from succeeding.   
-If the contest results in a tie, the situation remains the same as it was before the contest. Thus, one contestant might win the contest by default. If two characters tie in a contest to snatch a ring off the floor, neither character grabs it. In a contest between a monster trying to open a door and an adventurer trying to keep the door closed, a tie means that the door remains shut. 
 
-## Skills 
+If the contest results in a tie, the situation remains the same as it was before the contest. Thus, one contestant might win the contest by default. If two characters tie in a contest to snatch a ring off the floor, neither character grabs it. In a contest between a monster trying to open a door and an adventurer trying to keep the door closed, a tie means that the door remains shut.
+
+## Skills
 Each ability covers a broad range of capabilities, including skills that a character or a monster can be proficient in. A skill represents a specific aspect of an ability score, and an individual's proficiency in a skill demonstrates a focus on that aspect. (A character's starting skill proficiencies are determined at character creation, and a monster's skill proficiencies appear in the monster's stat block.)   
-For example, a Dexterity check might reflect a character's attempt to pull off an acrobatic stunt, to palm an object, or to stay hidden. Each of these aspects of Dexterity has an associated skill: Acrobatics, Sleight of Hand, and Stealth, respectively. So a character who has proficiency in the Stealth skill is particularly good at Dexterity checks related to sneaking and hiding.   
-The skills related to each ability score are shown in the following list. (No skills are related to Constitution.) See an ability's description in the later sections of this section for examples of how to use a skill associated with an ability. 
 
-### Strength 
-* Athletics 
+For example, a Dexterity check might reflect a character's attempt to pull off an acrobatic stunt, to palm an object, or to stay hidden. Each of these aspects of Dexterity has an associated skill: Acrobatics, Sleight of Hand, and Stealth, respectively. So a character who has proficiency in the Stealth skill is particularly good at Dexterity checks related to sneaking and hiding.  
 
-### Dexterity 
+The skills related to each ability score are shown in the following list. (No skills are related to Constitution.) See an ability's description in the later sections of this section for examples of how to use a skill associated with an ability.
+
+### Strength
+* Athletics
+
+### Dexterity
 * Acrobatics
-* Sleight of Hand 
-* Stealth 
+* Sleight of Hand
+* Stealth
 
 ### Intelligence
 * Arcana
 * History
 * Investigation
 * Nature
-* Religion 
+* Religion
 
 ### Wisdom
 * Animal Handling
 * Insight
 * Medicine
 * Perception
-* Survival 
+* Survival
 
-### Charisma 
+### Charisma
 * Deception
 * Intimidation
 * Performance
-* Persuasion 
+* Persuasion
 
 Sometimes, the GM might ask for an ability check using a specific skill--for example, “Make a Wisdom (Perception) check.” At other times, a player might ask the GM if proficiency in a particular skill applies to a check. In either case, proficiency in a skill means an individual can add his or her proficiency bonus to ability checks that involve that skill. Without proficiency in the skill, the individual makes a normal ability check.    
-For example, if a character attempts to climb up a dangerous cliff, the GM might ask for a Strength (Athletics) check. If the character is proficient in Athletics, the character's proficiency bonus is added to the Strength check. If the character lacks that proficiency, he or she just makes a Strength check. 
 
-### Variant: Skills with Different Abilities 
-Normally, your proficiency in a skill applies only to a specific kind of ability check. Proficiency in Athletics, for example, usually applies to Strength checks. In some situations, though, your proficiency might reasonably apply to a different kind of check. In such cases, the GM might ask for a check using an unusual combination of ability and skill, or you might ask your GM if you can apply a proficiency to a different check. For example, if you have to swim from an offshore island to the mainland, your GM might call for a Constitution check to see if you have the stamina to make it that far. In this case, your GM might allow you to apply your proficiency in Athletics and ask for a Constitution (Athletics) check. So if you're proficient in Athletics, you apply your proficiency bonus to the Constitution check just as you would normally do for a Strength (Athletics) check. Similarly, when your half-­‐‑orc barbarian uses a display of raw strength to intimidate an enemy, your GM might ask for a Strength (Intimidation) check, even though Intimidation is normally associated with Charisma. 
+For example, if a character attempts to climb up a dangerous cliff, the GM might ask for a Strength (Athletics) check. If the character is proficient in Athletics, the character's proficiency bonus is added to the Strength check. If the character lacks that proficiency, he or she just makes a Strength check.
 
-## Passive Checks 
+### Variant: Skills with Different Abilities
+Normally, your proficiency in a skill applies only to a specific kind of ability check. Proficiency in Athletics, for example, usually applies to Strength checks. In some situations, though, your proficiency might reasonably apply to a different kind of check. In such cases, the GM might ask for a check using an unusual combination of ability and skill, or you might ask your GM if you can apply a proficiency to a different check. For example, if you have to swim from an offshore island to the mainland, your GM might call for a Constitution check to see if you have the stamina to make it that far. In this case, your GM might allow you to apply your proficiency in Athletics and ask for a Constitution (Athletics) check. So if you're proficient in Athletics, you apply your proficiency bonus to the Constitution check just as you would normally do for a Strength (Athletics) check. Similarly, when your half-­‐‑orc barbarian uses a display of raw strength to intimidate an enemy, your GM might ask for a Strength (Intimidation) check, even though Intimidation is normally associated with Charisma.
+
+## Passive Checks
 A passive check is a special kind of ability check that doesn't involve any die rolls. Such a check can represent the average result for a task done repeatedly, such as searching for secret doors over and over again, or can be used when the GM wants to secretly determine whether the characters succeed at something without rolling dice, such as noticing a hidden monster.    
-Here's how to determine a character's total for a passive check: 
+
+Here's how to determine a character's total for a passive check:
 
 > 10 + all modifiers that normally apply to the check
 
- If the character has advantage on the check, add 5. For disadvantage, subtract 5. The game refers to a passive check total as a **score**.   
-For example, if a 1st-level character has a Wisdom of 15 and proficiency in Perception, he or she has a passive Wisdom (Perception) score of 14.    
-The rules on hiding in the “Dexterity” section below rely on passive checks, as do the exploration rules. 
+ If the character has advantage on the check, add 5. For disadvantage, subtract 5. The game refers to a passive check total as a **score**. For example, if a 1st-level character has a Wisdom of 15 and proficiency in Perception, he or she has a passive Wisdom (Perception) score of 14. The rules on hiding in the “Dexterity” section below rely on passive checks, as do the exploration rules.
 
-## Working Together 
+## Working Together
 Sometimes two or more characters team up to attempt a task. The character who's leading the effort--or the one with the highest ability modifier--can make an ability check with advantage, reflecting the help provided by the other characters. In combat, this requires the Help action.    
-A character can only provide help if the task is one that he or she could attempt alone. For example, trying to open a lock requires proficiency with thieves' tools, so a character who lacks that proficiency can't help another character in that task. Moreover, a character can help only when two or more individuals working together would actually be productive. Some tasks, such as threading a needle, are no easier with help. 
 
-### Group Checks 
+A character can only provide help if the task is one that he or she could attempt alone. For example, trying to open a lock requires proficiency with thieves' tools, so a character who lacks that proficiency can't help another character in that task. Moreover, a character can help only when two or more individuals working together would actually be productive. Some tasks, such as threading a needle, are no easier with help.
+
+### Group Checks
 When a number of individuals are trying to accomplish something as a group, the GM might ask for a group ability check. In such a situation, the characters who are skilled at a particular task help cover those who aren't.    
-To make a group ability check, everyone in the group makes the ability check. If at least half the group succeeds, the whole group succeeds.    
-Otherwise, the group fails. Group checks don't come up very often, and they're most useful when all the characters succeed or fail as a group. For example, when adventurers are navigating a swamp, the GM might call for a group Wisdom (Survival) check to see if the characters can avoid the quicksand, sinkholes, and other natural hazards of the environment. If at least half the group succeeds, the successful characters are able to guide their companions out of danger. Otherwise, the group stumbles into one of these hazards.
+
+To make a group ability check, everyone in the group makes the ability check. If at least half the group succeeds, the whole group succeeds. Otherwise, the group fails. Group checks don't come up very often, and they're most useful when all the characters succeed or fail as a group. For example, when adventurers are navigating a swamp, the GM might call for a group Wisdom (Survival) check to see if the characters can avoid the quicksand, sinkholes, and other natural hazards of the environment. If at least half the group succeeds, the successful characters are able to guide their companions out of danger. Otherwise, the group stumbles into one of these hazards.

--- a/docs/rules/abilities/ability_scores.md
+++ b/docs/rules/abilities/ability_scores.md
@@ -1,18 +1,20 @@
-# Ability Scores 
-Six abilities provide a quick description of every creature's physical and mental characteristics: 
+# Ability Scores
+Six abilities provide a quick description of every creature's physical and mental characteristics:
 
-* **Strength**, measuring physical power 
+* **Strength**, measuring physical power
 * **Dexterity**, measuring agility
 * **Constitution**, measuring endurance
 * **Intelligence**, measuring reasoning and memory
 * **Wisdom**, measuring perception and insight
-* **Charisma**, measuring force of personality 
+* **Charisma**, measuring force of personality
 
-Is a character muscle-bound and insightful? Brilliant and charming? Nimble and hardy? Ability scores define these qualities--a creature's assets as well as weaknesses. The three main rolls of the game--the ability check, the saving throw, and the attack roll--rely on the six ability scores. The book's introduction describes the basic rule behind these rolls: roll a d20, add an ability modifier derived from one of the six ability scores, and compare the total to a target number. 
+Is a character muscle-bound and insightful? Brilliant and charming? Nimble and hardy? Ability scores define these qualities--a creature's assets as well as weaknesses. The three main rolls of the game--the ability check, the saving throw, and the attack roll--rely on the six ability scores. The book's introduction describes the basic rule behind these rolls: roll a d20, add an ability modifier derived from one of the six ability scores, and compare the total to a target number.
 
-## Ability Scores and Modifiers 
+## Ability Scores and Modifiers
 Each of a creature's abilities has a score, a number that defines the magnitude of that ability. An ability score is not just a measure of innate capabilities, but also encompasses a creature's training and competence in activities related to that ability.    
+
 A score of 10 or 11 is the normal human average, but adventurers and many monsters are a cut above average in most abilities. A score of 18 is the highest that a person usually reaches. Adventurers can have scores as high as 20, and monsters and divine beings can have scores as high as 30.    
+
 Each ability also has a modifier, derived from the score and ranging from -5 (for an ability score of 1) to +10 (for a score of 30). The Ability Scores and Modifiers table notes the ability modifiers for the range of possible ability scores, from 1 to 30.
 
 | Score | Modifier |

--- a/docs/rules/abilities/charisma.md
+++ b/docs/rules/abilities/charisma.md
@@ -1,16 +1,26 @@
-# Charisma 
-Charisma measures your ability to interact effectively with others. It includes such factors as confidence and eloquence, and it can represent a charming or commanding personality. 
+# Charisma
+Charisma measures your ability to interact effectively with others. It includes such factors as confidence and eloquence, and it can represent a charming or commanding personality.
 
-## Charisma Checks 
+## Charisma Checks
 A Charisma check might arise when you try to influence or entertain others, when you try to make an impression or tell a convincing lie, or when you are navigating a tricky social situation. The Deception, Intimidation, Performance, and Persuasion skills reflect aptitude in certain kinds of Charisma checks.   
-**Deception.** Your Charisma (Deception) check determines whether you can convincingly hide the truth, either verbally or through your actions. This deception can encompass everything from misleading others through ambiguity to telling outright lies. Typical situations include trying to fast-talk a guard, con a merchant, earn money through gambling, pass yourself off in a disguise, dull someone's suspicions with false assurances, or maintain a straight face while telling a blatant lie.    
-**Intimidation.** When you attempt to influence someone through overt threats, hostile actions, and physical violence, the GM might ask you to make a Charisma (Intimidation) check. Examples include trying to pry information out of a prisoner, convincing street thugs to back down from a confrontation, or using the edge of a broken bottle to convince a sneering vizier to reconsider a decision.   
-**Performance.** Your Charisma (Performance) check determines how well you can delight an audience with music, dance, acting, storytelling, or some other form of entertainment.   
-**Persuasion.** When you attempt to influence someone or a group of people with tact, social graces, or good nature, the GM might ask you to make a Charisma (Persuasion) check. Typically, you use persuasion when acting in good faith, to foster friendships, make cordial requests, or exhibit proper etiquette. Examples of persuading others include convincing a chamberlain to let your party see the king, negotiating peace between warring tribes, or inspiring a crowd of townsfolk.    
-**Other Charisma Checks.** The GM might call for a Charisma check when you try to accomplish tasks like the following: 
+
+#### Deception
+Your Charisma (Deception) check determines whether you can convincingly hide the truth, either verbally or through your actions. This deception can encompass everything from misleading others through ambiguity to telling outright lies. Typical situations include trying to fast-talk a guard, con a merchant, earn money through gambling, pass yourself off in a disguise, dull someone's suspicions with false assurances, or maintain a straight face while telling a blatant lie.    
+
+#### Intimidation
+When you attempt to influence someone through overt threats, hostile actions, and physical violence, the GM might ask you to make a Charisma (Intimidation) check. Examples include trying to pry information out of a prisoner, convincing street thugs to back down from a confrontation, or using the edge of a broken bottle to convince a sneering vizier to reconsider a decision.   
+
+#### Performance
+Your Charisma (Performance) check determines how well you can delight an audience with music, dance, acting, storytelling, or some other form of entertainment.   
+
+#### Persuasion
+When you attempt to influence someone or a group of people with tact, social graces, or good nature, the GM might ask you to make a Charisma (Persuasion) check. Typically, you use persuasion when acting in good faith, to foster friendships, make cordial requests, or exhibit proper etiquette. Examples of persuading others include convincing a chamberlain to let your party see the king, negotiating peace between warring tribes, or inspiring a crowd of townsfolk.    
+
+#### Other Charisma Checks
+The GM might call for a Charisma check when you try to accomplish tasks like the following:
 
 * Find the best person to talk to for news, rumors, and gossip
-* Blend into a crowd to get the sense of key topics of conversation 
+* Blend into a crowd to get the sense of key topics of conversation
 
 ## Spellcasting Ability
 Bards, paladins, sorcerers, and warlocks use Charisma as their spellcasting ability, which helps determine the saving throw DCs of spells they cast.

--- a/docs/rules/abilities/constitution.md
+++ b/docs/rules/abilities/constitution.md
@@ -1,16 +1,18 @@
-# Constitution 
-Constitution measures health, stamina, and vital force. 
+# Constitution
+Constitution measures health, stamina, and vital force.
 
-## Constitution Checks 
+## Constitution Checks
 Constitution checks are uncommon, and no skills apply to Constitution checks, because the endurance this ability represents is largely passive rather than involving a specific effort on the part of a character or monster. A Constitution check can model your attempt to push beyond normal limits, however.    
-The GM might call for a Constitution check when you try to accomplish tasks like the following: 
+
+The GM might call for a Constitution check when you try to accomplish tasks like the following:
 
 * Hold your breath
 * March or labor for hours without rest
 * Go without sleep
 * Survive without food or water
-* Quaff an entire stein of ale in one go 
+* Quaff an entire stein of ale in one go
 
-## Hit Points 
-Your Constitution modifier contributes to your hit points. Typically, you add your Constitution modifier to each Hit Die you roll for your hit points.    
+## Hit Points
+Your Constitution modifier contributes to your hit points. Typically, you add your Constitution modifier to each Hit Die you roll for your hit points.  
+
 If your Constitution modifier changes, your hit point maximum changes as well, as though you had the new modifier from 1st level. For example, if you raise your Constitution score when you reach 4th level and your Constitution modifier increases from +1 to +2, you adjust your hit point maximum as though the modifier had always been +2. So you add 3 hit points for your first three levels, and then roll your hit points for 4th level using your new modifier. Or if you're 7th level and some effect lowers your Constitution score so as to reduce your Constitution modifier by 1, your hit point maximum is reduced by 7.

--- a/docs/rules/abilities/dexterity.md
+++ b/docs/rules/abilities/dexterity.md
@@ -1,35 +1,50 @@
-# Dexterity 
-Dexterity measures agility, reflexes, and balance. 
+# Dexterity
+Dexterity measures agility, reflexes, and balance.
 
-## Dexterity Checks 
+## Dexterity Checks
 A Dexterity check can model any attempt to move nimbly, quickly, or quietly, or to keep from falling on tricky footing. The Acrobatics, Sleight of Hand, and Stealth skills reflect aptitude in certain kinds of Dexterity checks.    
-**Acrobatics.** Your Dexterity (Acrobatics) check covers your attempt to stay on your feet in a tricky situation, such as when you're trying to run across a sheet of ice, balance on a tightrope, or stay upright on a rocking ship's deck. The GM might also call for a Dexterity (Acrobatics) check to see if you can perform acrobatic stunts, including dives, rolls, somersaults, and flips.    
-**Sleight of Hand.** Whenever you attempt an act of legerdemain or manual trickery, such as planting something on someone else or concealing an object on your person, make a Dexterity (Sleight of Hand) check. The GM might also call for a Dexterity (Sleight of Hand) check to determine whether you can lift a coin purse off another person or slip something out of another person's pocket.    
-**Stealth.** Make a Dexterity (Stealth) check when you attempt to conceal yourself from enemies, slink past guards, slip away without being noticed, or sneak up on someone without being seen or heard.    
-**Other Dexterity Checks.** The GM might call for a Dexterity check when you try to accomplish tasks like the following:
 
-* Control a heavily laden cart on a steep descent 
+#### Acrobatics
+Your Dexterity (Acrobatics) check covers your attempt to stay on your feet in a tricky situation, such as when you're trying to run across a sheet of ice, balance on a tightrope, or stay upright on a rocking ship's deck. The GM might also call for a Dexterity (Acrobatics) check to see if you can perform acrobatic stunts, including dives, rolls, somersaults, and flips.    
+
+#### Sleight of Hand
+Whenever you attempt an act of legerdemain or manual trickery, such as planting something on someone else or concealing an object on your person, make a Dexterity (Sleight of Hand) check. The GM might also call for a Dexterity (Sleight of Hand) check to determine whether you can lift a coin purse off another person or slip something out of another person's pocket.    
+
+#### Stealth
+Make a Dexterity (Stealth) check when you attempt to conceal yourself from enemies, slink past guards, slip away without being noticed, or sneak up on someone without being seen or heard.    
+
+#### Other Dexterity Checks
+The GM might call for a Dexterity check when you try to accomplish tasks like the following:
+
+* Control a heavily laden cart on a steep descent
 * Steer a chariot around a tight turn
-* Pick a lock 
+* Pick a lock
 * Disable a trap
-* Securely tie up a prisoner 
-* Wriggle free of bonds 
-* Play a stringed instrument 
-* Craft a small or detailed object 
+* Securely tie up a prisoner
+* Wriggle free of bonds
+* Play a stringed instrument
+* Craft a small or detailed object
 
-## Attack Rolls and Damage 
-You add your Dexterity modifier to your attack roll and your damage roll when attacking with a ranged weapon, such as a sling or a longbow. You can also add your Dexterity modifier to your attack roll and your damage roll when attacking with a melee weapon that has the finesse property, such as a dagger or a rapier. 
+## Attack Rolls and Damage
+You add your Dexterity modifier to your attack roll and your damage roll when attacking with a ranged weapon, such as a sling or a longbow. You can also add your Dexterity modifier to your attack roll and your damage roll when attacking with a melee weapon that has the finesse property, such as a dagger or a rapier.
 
-## Armor Class 
-Depending on the armor you wear, you might add some or all of your Dexterity modifier to your Armor Class. 
+## Armor Class
+Depending on the armor you wear, you might add some or all of your Dexterity modifier to your Armor Class.
 
-## Initiative 
-At the beginning of every combat, you roll initiative by making a Dexterity check. Initiative determines the order of creatures' turns in combat. 
+## Initiative
+At the beginning of every combat, you roll initiative by making a Dexterity check. Initiative determines the order of creatures' turns in combat.
 
->#### Hiding 
->The DM decides when circumstances are appropriate for hiding. When you try to hide, make a Dexterity (Stealth) check. Until you are discovered or you stop hiding, that check's total is contested by the Wisdom (Perception) check of any creature that actively searches for signs of your presence.   
->You can't hide from a creature that can see you clearly, and you give away your position if you make noise, such as shouting a warning or knocking over a vase. 
->An invisible creature can always try to hide. Signs of its passage might still be noticed, and it does have to stay quiet.   
->In combat, most creatures stay alert for signs of danger all around, so if you come out of hiding and approach a creature, it usually sees you. However, under certain circumstances, the DM might allow you to stay hidden as you approach a creature that is distracted, allowing you to gain advantage on an attack roll before you are seen.   
->**Passive Perception.** When you hide, there's a chance someone will notice you even if they aren't searching. To determine whether such a creature notices you, the DM compares your Dexterity (Stealth) check with that creature's passive Wisdom (Perception) score, which equals 10 + the creature's Wisdom modifier, as well as any other bonuses or penalties. If the creature has advantage, add 5. For disadvantage, subtract 5. For example, if a 1st-level character (with a proficiency bonus of +2) has a Wisdom of 15 (a +2 modifier) and proficiency in Perception, he or she has a passive Wisdom (Perception) of 14.    
->**What Can You See?** One of the main factors in determining whether you can find a hidden creature or object is how well you can see in an area, which might be **lightly** or **heavily obscured**
+## Hiding
+The DM decides when circumstances are appropriate for hiding. When you try to hide, make a Dexterity (Stealth) check. Until you are discovered or you stop hiding, that check's total is contested by the Wisdom (Perception) check of any creature that actively searches for signs of your presence.   
+
+You can't hide from a creature that can see you clearly, and you give away your position if you make noise, such as shouting a warning or knocking over a vase.
+
+An invisible creature can always try to hide. Signs of its passage might still be noticed, and it does have to stay quiet.   
+
+In combat, most creatures stay alert for signs of danger all around, so if you come out of hiding and approach a creature, it usually sees you. However, under certain circumstances, the DM might allow you to stay hidden as you approach a creature that is distracted, allowing you to gain advantage on an attack roll before you are seen.   
+
+#### Passive Perception
+When you hide, there's a chance someone will notice you even if they aren't searching. To determine whether such a creature notices you, the DM compares your Dexterity (Stealth) check with that creature's passive Wisdom (Perception) score, which equals 10 + the creature's Wisdom modifier, as well as any other bonuses or penalties. If the creature has advantage, add 5. For disadvantage, subtract 5. For example, if a 1st-level character (with a proficiency bonus of +2) has a Wisdom of 15 (a +2 modifier) and proficiency in Perception, he or she has a passive Wisdom (Perception) of 14.    
+
+#### What Can You See?
+One of the main factors in determining whether you can find a hidden creature or object is how well you can see in an area, which might be **lightly** or **heavily obscured**

--- a/docs/rules/abilities/intelligence.md
+++ b/docs/rules/abilities/intelligence.md
@@ -1,14 +1,26 @@
-# Intelligence 
-Intelligence measures mental acuity, accuracy of recall, and the ability to reason. 
+# Intelligence
+Intelligence measures mental acuity, accuracy of recall, and the ability to reason.
 
-## Intelligence Checks 
+## Intelligence Checks
 An Intelligence check comes into play when you need to draw on logic, education, memory, or deductive reasoning. The Arcana, History, Investigation, Nature, and Religion skills reflect aptitude in certain kinds of Intelligence checks.    
-**Arcana.** Your Intelligence (Arcana) check measures your ability to recall lore about spells, magic items, eldritch symbols, magical traditions, the planes of existence, and the inhabitants of those planes.    
-**History.** Your Intelligence (History) check measures your ability to recall lore about historical events, legendary people, ancient kingdoms, past disputes, recent wars, and lost civilizations.    
-**Investigation.** When you look around for clues and make deductions based on those clues, you make an Intelligence (Investigation) check. You might deduce the location of a hidden object, discern from the appearance of a wound what kind of weapon dealt it, or determine the weakest point in a tunnel that could cause it to collapse. Poring through ancient scrolls in search of a hidden fragment of knowledge might also call for an Intelligence (Investigation) check.    
-**Nature.** Your Intelligence (Nature) check measures your ability to recall lore about terrain, plants and animals, the weather, and natural cycles.    
-**Religion.** Your Intelligence (Religion) check measures your ability to recall lore about deities, rites and prayers, religious hierarchies, holy symbols, and the practices of secret cults.   
-**Other Intelligence Checks.** The GM might call for an Intelligence check when you try to accomplish tasks like the following: 
+
+#### Arcana
+Your Intelligence (Arcana) check measures your ability to recall lore about spells, magic items, eldritch symbols, magical traditions, the planes of existence, and the inhabitants of those planes.    
+
+#### History
+Your Intelligence (History) check measures your ability to recall lore about historical events, legendary people, ancient kingdoms, past disputes, recent wars, and lost civilizations.    
+
+#### Investigation
+When you look around for clues and make deductions based on those clues, you make an Intelligence (Investigation) check. You might deduce the location of a hidden object, discern from the appearance of a wound what kind of weapon dealt it, or determine the weakest point in a tunnel that could cause it to collapse. Poring through ancient scrolls in search of a hidden fragment of knowledge might also call for an Intelligence (Investigation) check.    
+
+#### Nature
+Your Intelligence (Nature) check measures your ability to recall lore about terrain, plants and animals, the weather, and natural cycles.    
+
+#### Religion
+Your Intelligence (Religion) check measures your ability to recall lore about deities, rites and prayers, religious hierarchies, holy symbols, and the practices of secret cults.   
+
+#### Other Intelligence Checks
+The GM might call for an Intelligence check when you try to accomplish tasks like the following:
 
 * Communicate with a creature without using words
 * Estimate the value of a precious item
@@ -17,5 +29,5 @@ An Intelligence check comes into play when you need to draw on logic, education,
 * Recall lore about a craft or trade
 * Win a game of skill
 
-## Spellcasting Ability 
+## Spellcasting Ability
 Wizards use Intelligence as their spellcasting ability, which helps determine the saving throw DCs of spells they cast.

--- a/docs/rules/abilities/saving_throws.md
+++ b/docs/rules/abilities/saving_throws.md
@@ -1,7 +1,12 @@
-# Saving Throws 
+# Saving Throws
 A saving throw--also called a save--represents an attempt to resist a spell, a trap, a poison, a disease, or a similar threat. You don’t normally decide to make a saving throw; you are forced to make one because your character or monster is at risk of harm.   
+
 To make a saving throw, roll a d20 and add the appropriate ability modifier. For example, you use your Dexterity modifier for a Dexterity saving throw.   
+
 A saving throw can be modified by a situational bonus or penalty and can be affected by advantage and disadvantage, as determined by the GM.    
+
 Each class gives proficiency in at least two saving throws. The wizard, for example, is proficient in Intelligence saves. As with skill proficiencies, proficiency in a saving throw lets a character add his or her proficiency bonus to saving throws made using a particular ability score. Some monsters have saving throw proficiencies as well.    
+
 The Difficulty Class for a saving throw is determined by the effect that causes it. For example, the DC for a saving throw allowed by a spell is determined by the caster’s spellcasting ability and proficiency bonus.    
+
 The result of a successful or failed saving throw is also detailed in the effect that allows the save. Usually, a successful save means that a creature suffers no harm, or reduced harm, from an effect.

--- a/docs/rules/abilities/strength.md
+++ b/docs/rules/abilities/strength.md
@@ -1,33 +1,42 @@
-# Strength 
-Strength measures bodily power, athletic training, and the extent to which you can exert raw physical force. 
+# Strength
+Strength measures bodily power, athletic training, and the extent to which you can exert raw physical force.
 
-## Strength Checks 
+## Strength Checks
 A Strength check can model any attempt to lift, push, pull, or break something, to force your body through a space, or to otherwise apply brute force to a situation. The Athletics skill reflects aptitude in certain kinds of Strength checks.    
-**Athletics.** Your Strength (Athletics) check covers difficult situations you encounter while climbing, jumping, or swimming. Examples include the following activities: 
 
-* You attempt to climb a sheer or slippery cliff, avoid hazards while scaling a wall, or cling to a surface while something is trying to knock you off. 
-* You try to jump an unusually long distance or pull off a stunt midjump. 
+#### Athletics
+Your Strength (Athletics) check covers difficult situations you encounter while climbing, jumping, or swimming. Examples include the following activities:
+
+* You attempt to climb a sheer or slippery cliff, avoid hazards while scaling a wall, or cling to a surface while something is trying to knock you off.
+* You try to jump an unusually long distance or pull off a stunt midjump.
 * You struggle to swim or stay afloat in treacherous currents, storm-tossed waves, or areas of thick seaweed. Or another creature tries to push or pull you underwater or otherwise interfere with your swimming.   
 
-**Other Strength Checks.** The GM might also call for a Strength check when you try to accomplish tasks like the following:
+#### Other Strength Checks
+The GM might also call for a Strength check when you try to accomplish tasks like the following:
 
-* Force open a stuck, locked, or barred door 
-* Break free of bonds 
-* Push through a tunnel that is too small 
-* Hang on to a wagon while being dragged behind it 
-* Tip over a statue 
+* Force open a stuck, locked, or barred door
+* Break free of bonds
+* Push through a tunnel that is too small
+* Hang on to a wagon while being dragged behind it
+* Tip over a statue
 * Keep a boulder from rolling
- 
-## Attack Rolls and Damage 
+
+## Attack Rolls and Damage
 You add your Strength modifier to your attack roll and your damage roll when attacking with a melee weapon such as a mace, a battleaxe, or a javelin. You use melee weapons to make melee attacks in hand-to-hand combat, and some of them can be thrown to make a ranged attack.
 
-## Lifting and Carrying 
+## Lifting and Carrying
 Your Strength score determines the amount of weight you can bear. The following terms define what you can lift or carry.    
-**Carrying Capacity.** Your carrying capacity is your Strength score multiplied by 15. This is the weight (in pounds) that you can carry, which is high enough that most characters don't usually have to worry about it.   
-**Push, Drag, or Lift.** You can push, drag, or lift a weight in pounds up to twice your carrying capacity (or 30 times your Strength score). While pushing or dragging weight in excess of your carrying capacity, your speed drops to 5 feet.    
-**Size and Strength.** Larger creatures can bear more weight, whereas Tiny creatures can carry less. For each size category above Medium, double the creature's carrying capacity and the amount it can push, drag, or lift. For a Tiny creature, halve these weights. 
 
-## Variant: Encumbrance 
+##### Carrying Capacity
+Your carrying capacity is your Strength score multiplied by 15. This is the weight (in pounds) that you can carry, which is high enough that most characters don't usually have to worry about it.   
+##### Push, Drag, or Lift
+You can push, drag, or lift a weight in pounds up to twice your carrying capacity (or 30 times your Strength score). While pushing or dragging weight in excess of your carrying capacity, your speed drops to 5 feet.    
+##### Size and Strength
+Larger creatures can bear more weight, whereas Tiny creatures can carry less. For each size category above Medium, double the creature's carrying capacity and the amount it can push, drag, or lift. For a Tiny creature, halve these weights.
+
+## Variant: Encumbrance
 The rules for lifting and carrying are intentionally simple. Here is a variant if you are looking for more detailed rules for determining how a character is hindered by the weight of equipment. When you use this variant, ignore the Strength column of the Armor table.    
+
 If you carry weight in excess of 5 times your Strength score, you are **encumbered**, which means your speed drops by 10 feet.    
+
 If you carry weight in excess of 10 times your Strength score, up to your maximum carrying capacity, you are instead **heavily encumbered**, which means your speed drops by 20 feet and you have disadvantage on ability checks, attack rolls, and saving throws that use Strength, Dexterity, or Constitution.

--- a/docs/rules/abilities/wisdom.md
+++ b/docs/rules/abilities/wisdom.md
@@ -1,17 +1,29 @@
-# Wisdom 
-Wisdom reflects how attuned you are to the world around you and represents perceptiveness and intuition. 
+# Wisdom
+Wisdom reflects how attuned you are to the world around you and represents perceptiveness and intuition.
 
 ## Wisdom Checks
 A Wisdom check might reflect an effort to read body language, understand someone’s feelings, notice things about the environment, or care for an injured person. The Animal Handling, Insight, Medicine, Perception, and Survival skills reflect aptitude in certain kinds of Wisdom checks.    
-**Animal Handling.** When there is any question whether you can calm down a domesticated animal, keep a mount from getting spooked, or intuit an animal’s intentions, the GM might call for a Wisdom (Animal Handling) check. You also make a Wisdom (Animal Handling) check to control your mount when you attempt a risky maneuver.    
-**Insight.** Your Wisdom (Insight) check decides whether you can determine the true intentions of a creature, such as when searching out a lie or predicting someone’s next move. Doing so involves gleaning clues from body language, speech habits, and changes in mannerisms.    
-**Medicine.** A Wisdom (Medicine) check lets you try to stabilize a dying companion or diagnose an illness.   
-**Perception.** Your Wisdom (Perception) check lets you spot, hear, or otherwise detect the presence of something. It measures your general awareness of your surroundings and the keenness of your senses. For example, you might try to hear a conversation through a closed door, eavesdrop under an open window, or hear monsters moving stealthily in the forest. Or you might try to spot things that are obscured or easy to miss, whether they are orcs lying in ambush on a road, thugs hiding in the shadows of an alley, or candlelight under a closed secret door.   
-**Survival.** The GM might ask you to make a Wisdom (Survival) check to follow tracks, hunt wild game, guide your group through frozen wastelands, identify signs that owlbears live nearby, predict the weather, or avoid quicksand and other natural hazards.    
-**Other Wisdom Checks.** The GM might call for a Wisdom check when you try to accomplish tasks like the following:
 
-* Get a gut feeling about what course of action to follow 
-* Discern whether a seemingly dead or living creature is undead 
+#### Animal Handling
+When there is any question whether you can calm down a domesticated animal, keep a mount from getting spooked, or intuit an animal’s intentions, the GM might call for a Wisdom (Animal Handling) check. You also make a Wisdom (Animal Handling) check to control your mount when you attempt a risky maneuver.    
 
-## Spellcasting Ability 
+#### Insight
+Your Wisdom (Insight) check decides whether you can determine the true intentions of a creature, such as when searching out a lie or predicting someone’s next move. Doing so involves gleaning clues from body language, speech habits, and changes in mannerisms.    
+
+#### Medicine
+A Wisdom (Medicine) check lets you try to stabilize a dying companion or diagnose an illness.   
+
+#### Perception
+Your Wisdom (Perception) check lets you spot, hear, or otherwise detect the presence of something. It measures your general awareness of your surroundings and the keenness of your senses. For example, you might try to hear a conversation through a closed door, eavesdrop under an open window, or hear monsters moving stealthily in the forest. Or you might try to spot things that are obscured or easy to miss, whether they are orcs lying in ambush on a road, thugs hiding in the shadows of an alley, or candlelight under a closed secret door.   
+
+#### Survival
+The GM might ask you to make a Wisdom (Survival) check to follow tracks, hunt wild game, guide your group through frozen wastelands, identify signs that owlbears live nearby, predict the weather, or avoid quicksand and other natural hazards.    
+
+#### Other Wisdom Checks
+The GM might call for a Wisdom check when you try to accomplish tasks like the following:
+
+* Get a gut feeling about what course of action to follow
+* Discern whether a seemingly dead or living creature is undead
+
+## Spellcasting Ability
 Clerics, druids, and rangers use Wisdom as their spellcasting ability, which helps determine the saving throw DCs of spells they cast.

--- a/docs/rules/advantage_and_disadvantage.md
+++ b/docs/rules/advantage_and_disadvantage.md
@@ -1,6 +1,10 @@
-# Advantage and Disadvantage 
+# Advantage and Disadvantage
 Sometimes a special ability or spell tells you that you have advantage or disadvantage on an ability check, a saving throw, or an attack roll. When that happens, you roll a second d20 when you make the roll. Use the higher of the two rolls if you have advantage, and use the lower roll if you have disadvantage. For example, if you have disadvantage and roll a 17 and a 5, you use the 5. If you instead have advantage and roll those numbers, you use the 17.    
+
 If multiple situations affect a roll and each one grants advantage or imposes disadvantage on it, you don't roll more than one additional d20. If two favorable situations grant advantage, for example, you still roll only one additional d20.    
+
 If circumstances cause a roll to have both advantage and disadvantage, you are considered to have neither of them, and you roll one d20. This is true even if multiple circumstances impose disadvantage and only one grants advantage or vice versa. In such a situation, you have neither advantage nor disadvantage.    
-When you have advantage or disadvantage and something in the game, such as the halfling's Lucky trait, lets you reroll the d20, you can reroll only one of the dice. You choose which one. For example, if a halfling has advantage or disadvantage on an ability check and rolls a 1 and a 13, the halfling could use the Lucky trait to reroll the 1.    
+
+When you have advantage or disadvantage and something in the game, such as the halfling's Lucky trait, lets you reroll the d20, you can reroll only one of the dice. You choose which one. For example, if a halfling has advantage or disadvantage on an ability check and rolls a 1 and a 13, the halfling could use the Lucky trait to reroll the 1.   
+ 
 You usually gain advantage or disadvantage through the use of special abilities, actions, or spells. Inspiration can also give a character advantage. The GM can also decide that circumstances influence a roll in one direction or the other and grant advantage or impose disadvantage as a result.

--- a/docs/rules/conditions.md
+++ b/docs/rules/conditions.md
@@ -1,22 +1,25 @@
-# Conditions 
-Conditions alter a creature's capabilities in a variety of ways and can arise as a result of a spell, a class feature, a monster's attack, or other effect. Most conditions, such as blinded, are impairments, but a few, such as invisible, can be advantageous.    
+# Conditions
+Conditions alter a creature's capabilities in a variety of ways and can arise as a result of a spell, a class feature, a monster's attack, or other effect. Most conditions, such as blinded, are impairments, but a few, such as invisible, can be advantageous.   
+
 A condition lasts either until it is countered (the prone condition is countered by standing up, for example) or for a duration specified by the effect that imposed the condition.    
+
 If multiple effects impose the same condition on a creature, each instance of the condition has its own duration, but the condition's effects don't get worse. A creature either has a condition or doesn't.    
-The following definitions specify what happens to a creature while it is subjected to a condition. 
+
+The following definitions specify what happens to a creature while it is subjected to a condition.
 
 ### Blinded
 * A blinded creature can't see and automatically fails any ability check that requires sight.
-* Attack rolls against the creature have advantage, and the creature's attack rolls have disadvantage. 
+* Attack rolls against the creature have advantage, and the creature's attack rolls have disadvantage.
 
-### Charmed 
+### Charmed
 * A charmed creature can't attack the charmer or target the charmer with harmful abilities or magical effects.
-* The charmer has advantage on any ability check to interact socially with the creature. 
+* The charmer has advantage on any ability check to interact socially with the creature.
 
 ### Deafened
-* A deafened creature can't hear and automatically fails any ability check that requires hearing. 
+* A deafened creature can't hear and automatically fails any ability check that requires hearing.
 
-### Exhaustion 
-Some special abilities and environmental hazards, such as starvation and the long-term effects of freezing or scorching temperatures, can lead to a special condition called exhaustion. Exhaustion is measured in six levels. An effect can give a creature one or more levels of exhaustion, as specified in the effect's description. 
+### Exhaustion
+Some special abilities and environmental hazards, such as starvation and the long-term effects of freezing or scorching temperatures, can lead to a special condition called exhaustion. Exhaustion is measured in six levels. An effect can give a creature one or more levels of exhaustion, as specified in the effect's description.
 
 | Level | Effect                                         |
 |-------|------------------------------------------------|
@@ -27,26 +30,29 @@ Some special abilities and environmental hazards, such as starvation and the lon
 | 5     | Speed reduced to 0                             |
 
 
-If an already exhausted creature suffers another effect that causes exhaustion, its current level of exhaustion increases by the amount specified in the effect's description.    
+If an already exhausted creature suffers another effect that causes exhaustion, its current level of exhaustion increases by the amount specified in the effect's description.  
+
 A creature suffers the effect of its current level of exhaustion as well as all lower levels. For example, a creature suffering level 2 exhaustion has its speed halved and has disadvantage on ability checks.    
+
 An effect that removes exhaustion reduces its level as specified in the effect's description, with all exhaustion effects ending if a creature's exhaustion level is reduced below 1.    
-Finishing a long rest reduces a creature's exhaustion level by 1, provided that the creature has also ingested some food and drink. 
+
+Finishing a long rest reduces a creature's exhaustion level by 1, provided that the creature has also ingested some food and drink.
 
 ### Frightened
 * A frightened creature has disadvantage on ability checks and attack rolls while the source of its fear is within line of sight.
-* The creature can't willingly move closer to the source of its fear. 
+* The creature can't willingly move closer to the source of its fear.
 
 ### Grappled
 * A grappled creature's speed becomes 0, and it can't benefit from any bonus to its speed.
 * The condition ends if the grappler is incapacitated (see the condition).
-* The condition also ends if an effect removes the grappled creature from the reach of the grappler or grappling effect, such as when a creature is hurled away by the **_thunder-wave_** spell. 
+* The condition also ends if an effect removes the grappled creature from the reach of the grappler or grappling effect, such as when a creature is hurled away by the **_thunder-wave_** spell.
 
 ### Incapacitated
-* An incapacitated creature can't take actions or reactions. 
+* An incapacitated creature can't take actions or reactions.
 
-### Invisible 
+### Invisible
 * An invisible creature is impossible to see without the aid of magic or a special sense. For the purpose of hiding, the creature is heavily obscured. The creature's location can be detected by any noise it makes or any tracks it leaves.
-* Attack rolls against the creature have disadvantage, and the creature's attack rolls have advantage. 
+* Attack rolls against the creature have disadvantage, and the creature's attack rolls have advantage.
 
 ### Paralyzed
 * A paralyzed creature is incapacitated (see the condition) and can't move or speak.
@@ -59,26 +65,26 @@ Finishing a long rest reduces a creature's exhaustion level by 1, provided that 
 * Attack rolls against the creature have advantage.
 * The creature automatically fails Strength and Dexterity saving throws.
 * The creature has resistance to all damage.
-* The creature is immune to poison and disease, although a poison or disease already in its system is suspended, not neutralized. 
+* The creature is immune to poison and disease, although a poison or disease already in its system is suspended, not neutralized.
 
 
 ### Poisoned
-* A poisoned creature has disadvantage on attack rolls and ability checks. 
+* A poisoned creature has disadvantage on attack rolls and ability checks.
 
 ### Prone
 * A prone creature's only movement option is to crawl, unless it stands up and thereby ends the condition.
 * The creature has disadvantage on attack rolls.
-* An attack roll against the creature has advantage if the attacker is within 5 feet of the creature. Otherwise, the attack roll has disadvantage. 
+* An attack roll against the creature has advantage if the attacker is within 5 feet of the creature. Otherwise, the attack roll has disadvantage.
 
 ### Restrained
 * A restrained creature's speed becomes 0, and it can't benefit from any bonus to its speed.
 * Attack rolls against the creature have advantage, and the creature's attack rolls have disadvantage.
-* The creature has disadvantage on Dexterity saving throws. 
+* The creature has disadvantage on Dexterity saving throws.
 
 ### Stunned
 * A stunned creature is incapacitated (see the condition), can't move, and can speak only falteringly.
 * The creature automatically fails Strength and Dexterity saving throws.
-* Attack rolls against the creature have advantage. 
+* Attack rolls against the creature have advantage.
 
 ### Unconscious
 * An unconscious creature is incapacitated (see the condition), can't move or speak, and is unaware of its surroundings

--- a/docs/rules/expenses.md
+++ b/docs/rules/expenses.md
@@ -1,9 +1,11 @@
-# Expenses 
-When not descending into the depths of the earth, exploring ruins for lost treasures, or waging war against the encroaching darkness, adventurers face more mundane realities. Even in a fantastical world, people require basic necessities such as shelter, sustenance, and clothing. These things cost money, although some lifestyles cost more than others. 
+# Expenses
+When not descending into the depths of the earth, exploring ruins for lost treasures, or waging war against the encroaching darkness, adventurers face more mundane realities. Even in a fantastical world, people require basic necessities such as shelter, sustenance, and clothing. These things cost money, although some lifestyles cost more than others.
 
-## Lifestyle Expenses 
+## Lifestyle Expenses
 Lifestyle expenses provide you with a simple way to account for the cost of living in a fantasy world. They cover your accommodations, food and drink, and all your other necessities. Furthermore, expenses cover the cost of maintaining your equipment so you can be ready when adventure next calls.    
+
 At the start of each week or month (your choice), choose a lifestyle from the Expenses table and pay the price to sustain that lifestyle. The prices listed are per day, so if you wish to calculate the cost of your chosen lifestyle over a thirty-day period, multiply the listed price by 30. Your lifestyle might change from one period to the next, based on the funds you have at your disposal, or you might maintain the same lifestyle throughout your character's career.    
+
 Your lifestyle choice can have consequences. Maintaining a wealthy lifestyle might help you make contacts with the rich and powerful, though you run the risk of attracting thieves. Likewise, living frugally might help you avoid criminals, but you are unlikely to make powerful connections.
 
 | Lifestyle    | Price/Day     |
@@ -16,19 +18,32 @@ Your lifestyle choice can have consequences. Maintaining a wealthy lifestyle mig
 | Wealthy      | 4 gp          |
 | Aristocratic | 10 gp minimum |
 
-**Wretched.** You live in inhumane conditions. With no place to call home, you shelter wherever you can, sneaking into barns, huddling in old crates, and relying on the good graces of people better off than you. A wretched lifestyle presents abundant dangers. Violence, disease, and hunger follow you wherever you go. Other wretched people covet your armor, weapons, and adventuring gear, which represent a fortune by their standards. You are beneath the notice of most people.    
-**Squalid.** You live in a leaky stable, a mud-floored hut just outside town, or a vermin-infested boarding house in the worst part of town. You have shelter from the elements, but you live in a desperate and often violent environment, in places rife with disease, hunger, and misfortune. You are beneath the notice of most people, and you have few legal protections. Most people at this lifestyle level have suffered some terrible setback. They might be disturbed, marked as exiles, or suffer from disease.    
-**Poor.** A poor lifestyle means going without the comforts available in a stable community. Simple food and lodgings, threadbare clothing, and unpredictable conditions result in a sufficient, though probably unpleasant, experience. Your accommodations might be a room in a flophouse or in the common room above a tavern. You benefit from some legal protections, but you still have to contend with violence, crime, and disease. People at this lifestyle level tend to be unskilled laborers, costermongers, peddlers, thieves, mercenaries, and other disreputable types.    
-**Modest.** A modest lifestyle keeps you out of the slums and ensures that you can maintain your equipment. You live in an older part of town, renting a room in a boarding house, inn, or temple. You don't go hungry or thirsty, and your living conditions are clean, if simple. Ordinary people living modest lifestyles include soldiers with families, laborers, students, priests, hedge wizards, and the like.    
-**Comfortable.** Choosing a comfortable lifestyle means that you can afford nicer clothing and can easily maintain your equipment. You live in a small cottage in a middle-class neighborhood or in a private room at a fine inn. You associate with merchants, skilled tradespeople, and military officers.    
-**Wealthy.** Choosing a wealthy lifestyle means living a life of luxury, though you might not have achieved the social status associated with the old money of nobility or royalty. You live a lifestyle comparable to that of a highly successful merchant, a favored servant of the royalty, or the owner of a few small businesses. You have respectable lodgings, usually a spacious home in a good part of town or a comfortable suite at a fine inn. You likely have a small staff of servants.    
-**Aristocratic.** You live a life of plenty and comfort. You move in circles populated by the most powerful people in the community. You have excellent lodgings, perhaps a townhouse in the nicest part of town or rooms in the finest inn. You dine at the best restaurants, retain the most skilled and fashionable tailor, and have servants attending to your every need. You receive invitations to the social gatherings of the rich and powerful, and spend evenings in the company of politicians, guild leaders, high priests, and nobility. You must also contend with the highest levels of deceit and treachery. The wealthier you are, the greater the chance you will be drawn into political intrigue as a pawn or participant.
+##### Wretched
+You live in inhumane conditions. With no place to call home, you shelter wherever you can, sneaking into barns, huddling in old crates, and relying on the good graces of people better off than you. A wretched lifestyle presents abundant dangers. Violence, disease, and hunger follow you wherever you go. Other wretched people covet your armor, weapons, and adventuring gear, which represent a fortune by their standards. You are beneath the notice of most people.   
+
+##### Squalid
+You live in a leaky stable, a mud-floored hut just outside town, or a vermin-infested boarding house in the worst part of town. You have shelter from the elements, but you live in a desperate and often violent environment, in places rife with disease, hunger, and misfortune. You are beneath the notice of most people, and you have few legal protections. Most people at this lifestyle level have suffered some terrible setback. They might be disturbed, marked as exiles, or suffer from disease.    
+
+##### Poor
+A poor lifestyle means going without the comforts available in a stable community. Simple food and lodgings, threadbare clothing, and unpredictable conditions result in a sufficient, though probably unpleasant, experience. Your accommodations might be a room in a flophouse or in the common room above a tavern. You benefit from some legal protections, but you still have to contend with violence, crime, and disease. People at this lifestyle level tend to be unskilled laborers, costermongers, peddlers, thieves, mercenaries, and other disreputable types.    
+
+##### Modest
+A modest lifestyle keeps you out of the slums and ensures that you can maintain your equipment. You live in an older part of town, renting a room in a boarding house, inn, or temple. You don't go hungry or thirsty, and your living conditions are clean, if simple. Ordinary people living modest lifestyles include soldiers with families, laborers, students, priests, hedge wizards, and the like.    
+
+##### Comfortable
+Choosing a comfortable lifestyle means that you can afford nicer clothing and can easily maintain your equipment. You live in a small cottage in a middle-class neighborhood or in a private room at a fine inn. You associate with merchants, skilled tradespeople, and military officers.    
+
+##### Wealthy
+Choosing a wealthy lifestyle means living a life of luxury, though you might not have achieved the social status associated with the old money of nobility or royalty. You live a lifestyle comparable to that of a highly successful merchant, a favored servant of the royalty, or the owner of a few small businesses. You have respectable lodgings, usually a spacious home in a good part of town or a comfortable suite at a fine inn. You likely have a small staff of servants.    
+
+##### Aristocratic
+You live a life of plenty and comfort. You move in circles populated by the most powerful people in the community. You have excellent lodgings, perhaps a townhouse in the nicest part of town or rooms in the finest inn. You dine at the best restaurants, retain the most skilled and fashionable tailor, and have servants attending to your every need. You receive invitations to the social gatherings of the rich and powerful, and spend evenings in the company of politicians, guild leaders, high priests, and nobility. You must also contend with the highest levels of deceit and treachery. The wealthier you are, the greater the chance you will be drawn into political intrigue as a pawn or participant.
 
 ### Self-Sufficiency
 The expenses and lifestyles described here assume that you are spending your time between adventures in town, availing yourself of whatever services you can afford--paying for food and shelter, paying townspeople to sharpen your sword and repair your armor, and so on. Some characters, though, might prefer to spend their time away from civilization, sustaining themselves in the wild by hunting, foraging, and repairing their own gear.    
 Maintaining this kind of lifestyle doesn't require you to spend any coin, but it is time-consuming. If you spend your time between adventures practicing a profession, you can eke out the equivalent of a poor lifestyle. Proficiency in the Survival skill lets you live at the equivalent of a comfortable lifestyle.
 
-## Food, Drink, and Lodging 
+## Food, Drink, and Lodging
 The Food, Drink, and Lodging table gives prices for individual food items and a single night's lodging. These prices are included in your total lifestyle expenses.
 
 **Food and Drink**
@@ -55,9 +70,11 @@ The Food, Drink, and Lodging table gives prices for individual food items and a 
 | Wealthy      | 8 sp       | 2 gp         |
 | Aristocratic | 2 gp       | 4 gp         |
 
-## Services 
-Adventurers can pay nonplayer characters to assist them or act on their behalf in a variety of circumstances. Most such hirelings have fairly ordinary skills, while others are masters of a craft or art, and a few are experts with specialized adventuring skills.    
+## Services
+Adventurers can pay nonplayer characters to assist them or act on their behalf in a variety of circumstances. Most such hirelings have fairly ordinary skills, while others are masters of a craft or art, and a few are experts with specialized adventuring skills.  
+
 Some of the most basic types of hirelings appear on the Services table. Other common hirelings include any of the wide variety of people who inhabit a typical town or city, when the adventurers pay them to perform a specific task. For example, a wizard might pay a carpenter to construct an elaborate chest (and its miniature replica) for use in the secret chest spell. A fighter might commission a blacksmith to forge a special sword. A bard might pay a tailor to make exquisite clothing for an upcoming performance in front of the duke.    
+
 Other hirelings provide more expert or dangerous services. Mercenary soldiers paid to help the adventurers take on a hobgoblin army are hirelings, as are sages hired to research ancient or esoteric lore. If a high-level adventurer establishes a stronghold of some kind, he or she might hire a whole staff of servants and agents to run the place, from a castellan or steward to menial laborers to keep the stables clean. These hirelings often enjoy a long-term contract that includes a place to live within the stronghold as part of the offered compensation.
 
 | Service                   | Pay           |
@@ -70,8 +87,9 @@ Other hirelings provide more expert or dangerous services. Mercenary soldiers pa
 | Road or gate toll         | 1 cp          |
 | Ship's passage            | 1 sp per mile |
 
-Skilled hirelings include anyone hired to perform a service that involves a proficiency (including weapon, tool, or skill): a mercenary, artisan, scribe, and so on. The pay shown is a minimum; some expert hirelings require more pay. Untrained hirelings are hired for menial work that requires no particular skill and can include laborers, porters, maids, and similar workers. 
+Skilled hirelings include anyone hired to perform a service that involves a proficiency (including weapon, tool, or skill): a mercenary, artisan, scribe, and so on. The pay shown is a minimum; some expert hirelings require more pay. Untrained hirelings are hired for menial work that requires no particular skill and can include laborers, porters, maids, and similar workers.
 
-## Spellcasting Services 
+## Spellcasting Services
 People who are able to cast spells don't fall into the category of ordinary hirelings. It might be possible to find someone willing to cast a spell in exchange for coin or favors, but it is rarely easy and no established pay rates exist. As a rule, the higher the level of the desired spell, the harder it is to find someone who can cast it and the more it costs.    
+
 Hiring someone to cast a relatively common spell of 1st or 2nd level, such as **_cure wounds_** or **_identify_**, is easy enough in a city or town, and might cost 10 to 50 gold pieces (plus the cost of any expensive material components). Finding someone able and willing to cast a higher-level spell might involve traveling to a large city, perhaps one with a university or prominent temple. Once found, the spellcaster might ask for a service instead of payment--the kind of service that only adventurers can provide, such as retrieving a rare item from a dangerous locale or traversing a monster-infested wilderness to deliver something important to a distant settlement.

--- a/docs/rules/feats.md
+++ b/docs/rules/feats.md
@@ -1,9 +1,11 @@
-# Feats 
+# Feats
 A feat represents a talent or an area of expertise that gives a character special capabilities. It embodies training, experience, and abilities beyond what a class provides.    
+
 At certain levels, your class gives you the Ability Score Improvement feature. Using the optional feats rule, you can forgo taking that feature to take a feat of your choice instead. You can take each feat only once, unless the feat's description says otherwise.    
+
 You must meet any prerequisite specified in a feat to take that feat. If you ever lose a feat's prerequisite, you can't use that feat until you regain the prerequisite. For example, the Grappler feat requires you to have a Strength of 13 or higher. If your Strength is reduced below 13 somehow--perhaps by a withering curse--you can't benefit from the Grappler feat until your Strength is restored.
 
-## Grappler 
+## Grappler
 **Prerequisite:** Strength 13 or higher    
 You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:
 

--- a/docs/rules/leveling_up.md
+++ b/docs/rules/leveling_up.md
@@ -1,31 +1,36 @@
 # Leveling Up
 As your character goes on adventures and overcomes challenges, he or she gains experience, represented by experience points. A character who reaches a specified experience point total advances in capability. This advancement is called **gaining a level**.    
+
 When your character gains a level, his or her class often grants additional features, as detailed in the class description. Some of these features allow you to increase your ability scores, either increasing two scores by 1 each or increasing one score by 2. You can’t increase an ability score above 20. In addition, every character's proficiency bonus increases at certain levels.    
+
+The *Character Advancement* table summarizes the XP you need to advance in levels from level 1 through level 20, and the proficiency bonus for a character of that level. Consult the information in your character's class description to see what other improvements you gain at each level.
+
+### Health
 Each time you gain a level, you gain 1 additional Hit Die. Roll that Hit Die, add your Constitution modifier to the roll, and add the total to your hit point maximum. Alternatively, you can use the fixed value shown in your class entry, which is the average result of the die roll (rounded up).    
+
 When your Constitution modifier increases by 1, your hit point maximum increases by 1 for each level you have attained. For example, if your 7th-level fighter has a Constitution score of 18, when he reaches 8th level, he increases his Constitution score from 17 to 18, thus increasing his Constitution modifier from +3 to +4. His hit point maximum then increases by 8.    
-The Character Advancement table summarizes the XP you need to advance in levels from level 1 through level 20, and the proficiency bonus for a character of that level. Consult the information in your character.s class description to see what other improvements you gain at each level.
 
-**Character Advancement**
+### Character Advancement
 
-| Experience Points | Level | Proficiency Bonus |
-|-------------------|-------|-------------------|
-| 0                 | 1     | +2                |
-| 300               | 2     | +2                |
-| 900               | 3     | +2                |
-| 2,700             | 4     | +2                |
-| 6,500             | 5     | +3                |
-| 14,000            | 6     | +3                |
-| 23,000            | 7     | +3                |
-| 34,000            | 8     | +3                |
-| 48,000            | 9     | +4                |
-| 64,000            | 10    | +4                |
-| 85,000            | 11    | +4                |
-| 100,000           | 12    | +4                |
-| 120,000           | 13    | +5                |
-| 140,000           | 14    | +5                |
-| 165,000           | 15    | +5                |
-| 195,000           | 16    | +5                |
-| 225,000           | 17    | +6                |
-| 265,000           | 18    | +6                |
-| 305,000           | 19    | +6                |
-| 335,000           | 20    | +6                |
+| Level | XP Requirement (points) | Total Proficiency Bonus |
+|-------|-------------------------|-------------------------|
+| 1     | 0                       | +2                      |
+| 2     | 300                     | +2                      |
+| 3     | 900                     | +2                      |
+| 4     | 2,700                   | +2                      |
+| 5     | 6,500                   | +3                      |
+| 6     | 14,000                  | +3                      |
+| 7     | 23,000                  | +3                      |
+| 8     | 34,000                  | +3                      |
+| 9     | 48,000                  | +4                      |
+| 10    | 64,000                  | +4                      |
+| 11    | 85,000                  | +4                      |
+| 12    | 100,000                 | +4                      |
+| 13    | 120,000                 | +5                      |
+| 14    | 140,000                 | +5                      |
+| 15    | 165,000                 | +5                      |
+| 16    | 195,000                 | +5                      |
+| 17    | 225,000                 | +6                      |
+| 18    | 265,000                 | +6                      |
+| 19    | 305,000                 | +6                      |
+| 20    | 335,000                 | +6                      |

--- a/docs/rules/multiclassing.md
+++ b/docs/rules/multiclassing.md
@@ -1,7 +1,9 @@
-# Multiclassing 
+# Multiclassing
 Multiclassing allows you to gain levels in multiple classes. Doing so lets you mix the abilities of those classes to realize a character concept that might not be reflected in one of the standard class options.    
-With this rule, you have the option of gaining a level in a new class whenever you advance in level, instead of gaining a level in your current class. Your levels in all your classes are added together to determine your character level. For example, if you have three levels in wizard and two in fighter, you're a 5th-level character.    
-As you advance in levels, you might primarily remain a member of your original class with just a few levels in another class, or you might change course entirely, never looking back at the class you left behind. You might even start progressing in a third or fourth class. Compared to a single-class character of the same level, you'll sacrifice some focus in exchange for versatility. 
+
+With this rule, you have the option of gaining a level in a new class whenever you advance in level, instead of gaining a level in your current class. Your levels in all your classes are added together to determine your character level. For example, if you have three levels in wizard and two in fighter, you're a 5th-level character.   
+
+As you advance in levels, you might primarily remain a member of your original class with just a few levels in another class, or you might change course entirely, never looking back at the class you left behind. You might even start progressing in a third or fourth class. Compared to a single-class character of the same level, you'll sacrifice some focus in exchange for versatility.
 
 ## Prerequisites
 To qualify for a new class, you must meet the ability score prerequisites for both your current class and your new one, as shown in the Multiclassing Prerequisites table. For example, a barbarian who decides to multiclass into the druid class must have both Strength and Wisdom scores of 13 or higher. Without the full training that a beginning character receives, you must be a quick study in your new class, having a natural aptitude that is reflected by higher-than-average ability scores.
@@ -21,17 +23,18 @@ To qualify for a new class, you must meet the ability score prerequisites for bo
 | Warlock   | Charisma 13                 |
 | Wizard    | Intelligence 13             |
 
-## Experience Points 
-The experience point cost to gain a level is always based on your total character level, as shown in the Character Advancement table, not your level in a particular class. So, if you are a cleric 6/fighter 1, you must gain enough XP to reach 8th level before you can take your second level as a fighter or your seventh level as a cleric. 
+## Experience Points
+The experience point cost to gain a level is always based on your total character level, as shown in the Character Advancement table, not your level in a particular class. So, if you are a cleric 6/fighter 1, you must gain enough XP to reach 8th level before you can take your second level as a fighter or your seventh level as a cleric.
 
-## Hit Points and Hit Dice 
-You gain the hit points from your new class as described for levels after 1st. You gain the 1st-level hit points for a class only when you are a 1st-level character.    
-You add together the Hit Dice granted by all your classes to form your pool of Hit Dice. If the Hit Dice are the same die type, you can simply pool them together. For example, both the fighter and the paladin have a d10, so if you are a paladin 5/fighter 5, you have ten d10 Hit Dice. If your classes give you Hit Dice of different types, keep track of them separately. If you are a paladin 5/cleric 5, for example, you have five d10 Hit Dice and five d8 Hit Dice. 
+## Hit Points and Hit Dice
+You gain the hit points from your new class as described for levels after 1st. You gain the 1st-level hit points for a class only when you are a 1st-level character.   
 
-## Proficiency Bonus 
-Your proficiency bonus is always based on your total character level, not your level in a particular class. For example, if you are a fighter 3/rogue 2, you have the proficiency bonus of a 5th-level character, which is +3. 
+You add together the Hit Dice granted by all your classes to form your pool of Hit Dice. If the Hit Dice are the same die type, you can simply pool them together. For example, both the fighter and the paladin have a d10, so if you are a paladin 5/fighter 5, you have ten d10 Hit Dice. If your classes give you Hit Dice of different types, keep track of them separately. If you are a paladin 5/cleric 5, for example, you have five d10 Hit Dice and five d8 Hit Dice.
 
-## Proficiencies 
+## Proficiency Bonus
+Your proficiency bonus is always based on your total character level, not your level in a particular class. For example, if you are a fighter 3/rogue 2, you have the proficiency bonus of a 5th-level character, which is +3.
+
+## Proficiencies
 When you gain your first level in a class other than your initial class, you gain only some of new class's starting proficiencies, as shown in the Multiclassing Proficiencies table.
 
 #### Multiclassing Proficiencies
@@ -46,30 +49,39 @@ When you gain your first level in a class other than your initial class, you gai
 | Paladin   | Light armor, medium armor, shields, simple weapons, martial weapons |
 | Ranger    | Light armor, medium armor, shields, simple weapons, martial weapons, one skill from the class's skill list |
 | Rogue     | Light armor, one skill from the class's skill list, thieves' tools |
-| Sorcerer  | - |
+| Sorcerer  | *N/A* |
 | Warlock   | Light armor, simple weapons |
-| Wizard    | - |
+| Wizard    | *N/A* |
 
-## Class Features 
-When you gain a new level in a class, you get its features for that level. You don't, however, receive the class's starting equipment, and a few features have additional rules when you're multiclassing: Channel Divinity, Extra Attack, Unarmored Defense, and Spellcasting. 
+## Class Features
+When you gain a new level in a class, you get its features for that level. You don't, however, receive the class's starting equipment, and a few features have additional rules when you're multiclassing: Channel Divinity, Extra Attack, Unarmored Defense, and Spellcasting.
 
-### Channel Divinity 
-If you already have the Channel Divinity feature and gain a level in a class that also grants the feature, you gain the Channel Divinity effects granted by that class, but getting the feature again doesn't give you an additional use of it. You gain additional uses only when you reach a class level that explicitly grants them to you. For example, if you are a cleric 6/paladin 4, you can use Channel Divinity twice between rests because you are high enough level in the cleric class to have more uses. Whenever you use the feature, you can choose any of the Channel Divinity effects available to you from your two classes. 
+### Channel Divinity
+If you already have the Channel Divinity feature and gain a level in a class that also grants the feature, you gain the Channel Divinity effects granted by that class, but getting the feature again doesn't give you an additional use of it. You gain additional uses only when you reach a class level that explicitly grants them to you. For example, if you are a cleric 6/paladin 4, you can use Channel Divinity twice between rests because you are high enough level in the cleric class to have more uses. Whenever you use the feature, you can choose any of the Channel Divinity effects available to you from your two classes.
 
-### Extra Attack 
-If you gain the Extra Attack class feature from more than one class, the features don't add together. You can't make more than two attacks with this feature unless it says you do (as the fighter's version of Extra Attack does). Similarly, the warlock's eldritch invocation Thirsting Blade doesn't give you additional attacks if you also have Extra Attack. 
+### Extra Attack
+If you gain the Extra Attack class feature from more than one class, the features don't add together. You can't make more than two attacks with this feature unless it says you do (as the fighter's version of Extra Attack does). Similarly, the warlock's eldritch invocation Thirsting Blade doesn't give you additional attacks if you also have Extra Attack.
 
-### Unarmored Defense 
-If you already have the Unarmored Defense feature, you can't gain it again from another class. 
+### Unarmored Defense
+If you already have the Unarmored Defense feature, you can't gain it again from another class.
 
-### Spellcasting 
+### Spellcasting
 Your capacity for spellcasting depends partly on your combined levels in all your spellcasting classes and partly on your individual levels in those classes. Once you have the Spellcasting feature from more than one class, use the rules below. If you multiclass but have the Spellcasting feature from only one class, you follow the rules as described in that class.    
-**Spells Known and Prepared.** You determine what spells you know and can prepare for each class individually, as if you were a single-classed member of that class. If you are a ranger 4/wizard 3, for example, you know three 1st-level ranger spells based on your levels in the ranger class. As 3rd-level wizard, you know three wizard cantrips, and your spellbook contains ten wizard spells, two of which (the two you gained when you reached 3rd level as a wizard) can be 2nd-level spells. If your Intelligence is 16, you can prepare six wizard spells from your spellbook.    
+
+#### Spells Known and Prepared
+You determine what spells you know and can prepare for each class individually, as if you were a single-classed member of that class. If you are a ranger 4/wizard 3, for example, you know three 1st-level ranger spells based on your levels in the ranger class. As 3rd-level wizard, you know three wizard cantrips, and your spellbook contains ten wizard spells, two of which (the two you gained when you reached 3rd level as a wizard) can be 2nd-level spells. If your Intelligence is 16, you can prepare six wizard spells from your spellbook.    
+
 Each spell you know and prepare is associated with one of your classes, and you use the spellcasting ability of that class when you cast the spell. Similarly, a spellcasting focus, such as a holy symbol, can be used only for the spells from the class associated with that focus.    
-**Spell Slots.** You determine your available spell slots by adding together all your levels in the bard, cleric, druid, sorcerer, and wizard classes, and half your levels (rounded down) in the paladin and ranger classes. Use this total to determine your spell slots by consulting the Multiclass Spellcaster table.    
+
+#### Spell Slots
+You determine your available spell slots by adding together all your levels in the bard, cleric, druid, sorcerer, and wizard classes, and half your levels (rounded down) in the paladin and ranger classes. Use this total to determine your spell slots by consulting the Multiclass Spellcaster table.    
+
 If you have more than one spellcasting class, this table might give you spell slots of a level that is higher than the spells you know or can prepare. You can use those slots, but only to cast your lower-level spells. If a lower-level spell that you cast, like **_burning hands_**, has an enhanced effect when cast using a higher-level slot, you can use the enhanced effect, even though you don't have any spells of that higher level.    
+
 For example, if you are the aforementioned ranger 4/wizard 3, you count as a 5th-level character when determining your spell slots: you have four 1st-level slots, three 2nd-level slots, and two 3rd-level slots. However, you don't know any 3rd-level spells, nor do you know any 2nd-level ranger spells. You can use the spell slots of those levels to cast the spells you do know — and potentially enhance their effects.    
-**Pact Magic.** If you have both the Spellcasting class feature and the Pact Magic class feature from the warlock class, you can use the spell slots you gain from the Pact Magic feature to cast spells you know or have prepared from classes with the Spellcasting class feature, and you can use the spell slots you gain from the Spellcasting class feature to cast warlock spells you know.
+
+#### Pact Magic
+If you have both the Spellcasting class feature and the Pact Magic class feature from the warlock class, you can use the spell slots you gain from the Pact Magic feature to cast spells you know or have prepared from classes with the Spellcasting class feature, and you can use the spell slots you gain from the Spellcasting class feature to cast warlock spells you know.
 
 #### Multiclass Spellcaster: Spell Slots per Spell Level
 | Level | 1st | 2nd | 3rd | 4th | 5th | 6th | 7th | 8th | 9th |

--- a/docs/rules/proficiency_bonus.md
+++ b/docs/rules/proficiency_bonus.md
@@ -1,6 +1,10 @@
-# Proficiency Bonus 
+# Proficiency Bonus
 Characters have a proficiency bonus determined by level. Monsters also have this bonus, which is incorporated in their stat blocks. The bonus is used in the rules on ability checks, saving throws, and attack rolls.   
+
 Your proficiency bonus can't be added to a single die roll or other number more than once. For example, if two different rules say you can add your proficiency bonus to a Wisdom saving throw, you nevertheless add the bonus only once when you make the save.   
-Occasionally, your proficiency bonus might be multiplied or divided (doubled or halved, for example) before you apply it. For example, the rogue's Expertise feature doubles the proficiency bonus for certain ability checks. If a circumstance suggests that your proficiency bonus applies more than once to the same roll, you still add it only once and multiply or divide it only once.   
+
+Occasionally, your proficiency bonus might be multiplied or divided (doubled or halved, for example) before you apply it. For example, the rogue's Expertise feature doubles the proficiency bonus for certain ability checks. If a circumstance suggests that your proficiency bonus applies more than once to the same roll, you still add it only once and multiply or divide it only once.
+
 By the same token, if a feature or effect allows you to multiply your proficiency bonus when making an ability check that wouldn't normally benefit from your proficiency bonus, you still don't add the bonus to the check. For that check your proficiency bonus is 0, given the fact that multiplying 0 by any number is still 0. For instance, if you lack proficiency in the History skill, you gain no benefit from a feature that lets you double your proficiency bonus when you make Intelligence (History) checks.   
+
 In general, you don't multiply your proficiency bonus for attack rolls or saving throws. If a feature or effect allows you to do so, these same rules apply.


### PR DESCRIPTION
I took some time and adjusted the formatting for the Rules section to delineate the paragraphs a bit better. Additionally, I adjusted `Actions in Combat`, `Cover`, and `Damage and Healing` sections in Combat. 

I also made a few changes on the `Leveling Up` page because a player of mine was getting confused by the Proficiency Bonus column on the chart.
