### PR TITLE
Repositioned the "Contests in Combat" sidebar

### DIFF
--- a/docs/combat/making_an_attack.md
+++ b/docs/combat/making_an_attack.md
@@ -51,14 +51,14 @@ You can avoid provoking an opportunity attack by taking the Disengage action. Yo
 When you take the Attack action and attack with a light melee weapon that you're holding in one hand, you can use a bonus action to attack with a different light melee weapon that you're holding in the other hand. You don't add your ability modifier to the damage of the bonus attack, unless that modifier is negative.    
 If either weapon has the thrown property, you can throw the weapon, instead of making a melee attack with it. 
 
+> ### Contests in Combat 
+> Battle often involves pitting your prowess against that of your foe. Such a challenge is represented by a contest. This section includes the most common contests that require an action in combat: grappling and shoving a creature. The GM can use these contests as models for improvising others. 
+
 ### Grappling 
 When you want to grab a creature or wrestle with it, you can use the Attack action to make a special melee attack, a grapple. If you're able to make multiple attacks with the Attack action, this attack replaces one of them.    
 The target of your grapple must be no more than one size larger than you and must be within your reach. Using at least one free hand, you try to seize the target by making a grapple check instead of an attack roll: a Strength (Athletics) check contested by the target's Strength (Athletics) or Dexterity (Acrobatics) check (the target chooses the ability to use). If you succeed, you subject the target to the grappled condition. The condition specifies the things that end it, and you can release the target whenever you like (no action required).    
 **Escaping a Grapple.** A grappled creature can use its action to escape. To do so, it must succeed on a Strength (Athletics) or Dexterity (Acrobatics) check contested by your Strength (Athletics) check.   
 **Moving a Grappled Creature.** When you move, you can drag or carry the grappled creature with you, but your speed is halved, unless the creature is two or more sizes smaller than you.    
-
-> ### Contests in Combat 
-> Battle often involves pitting your prowess against that of your foe. Such a challenge is represented by a contest. This section includes the most common contests that require an action in combat: grappling and shoving a creature. The GM can use these contests as models for improvising others. 
 
 ### Shoving a Creature 
 Using the Attack action, you can make a special melee attack to shove a creature, either to knock it prone or push it away from you. If you're able to make multiple attacks with the Attack action, this attack replaces one of them.    


### PR DESCRIPTION
The sidebar for "Contests in Combat" in the "Making an Attack" page refers to grappling and shoving, so in this non-book layout it makes more sense to locate it before the grappling and shoving sections instead of between them.
