### PR TITLE
Missing "College of Valor" in bard.md

### DIFF
--- a/docs/character/classes/bard.md
+++ b/docs/character/classes/bard.md
@@ -138,3 +138,19 @@ At 6th level, you learn two spells of your choice from any class. A spell you ch
 
 #### Peerless Skill 
 Starting at 14th level, when you make an ability check, you can expend one use of Bardic Inspiration. Roll a Bardic Inspiration die and add the number rolled to your ability check. You can choose to do so after you roll the die for the ability check, but before the GM tells you whether you succeed or fail.
+
+## College of Valor 
+- - -
+Bards of the College of Valor are daring skalds whose tales keep alive the memory of the great heroes of the past, and thereby inspire a new generation of heroes. These bards gather in mead halls or around great bonfires to sing the deeds of the mighty, both past and present. They travel the land to witness great events firsthand and to ensure that the memory of those events doesn’t pass from the world. With their songs, they inspire others to reach the same heights of accomplishment as the heroes of old.
+
+#### Bonus Proficiencies 
+When you join the College of Valor at 3rd level, you gain proficiency with medium armor, shields, and martial weapons. 
+
+#### Combat Inspiration
+Also at 3rd level, you learn to inspire others in battle. A creature that has a Bardic Inspiration die from you can roll that die and add the number rolled to a weapon damage roll it just made. Alternatively, when an attack roll is made against the creature, it can use its reaction to roll the Bardic Inspiration die and add the number rolled to its AC against that attack, after seeing the roll but before knowing whether it hits or misses.
+
+#### Extra Attack
+Starting at 6th level, you can attack twice, instead of once, whenever you take the Attack action on your turn
+
+#### Battle Magic
+At 14th level, you have mastered the art of weaving spellcasting and weapon use into a single harmonious act. When you use your action to cast a bard spell, you can make one weapon attack as a bonus action.


### PR DESCRIPTION
Information about the College of Valor, mentioned in both the Player's Handbook and the "Bard College" section of this document, was not present.