### PR TITLE
Fix Dire Wolf Formatting

### DIFF
--- a/docs/gamemaster_rules/monsters/dire_wolf.md
+++ b/docs/gamemaster_rules/monsters/dire_wolf.md
@@ -18,7 +18,9 @@ _Large beast, unaligned_
 **Languages** --    
 **Challenge** 1 (200 XP) 
 
-**Keen Hearing and Smell.** The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell. Pack Tactics. The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 feet of the creature and the ally isn't incapacitated. 
+**Keen Hearing and Smell.** The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell.
+
+**Pack Tactics.** The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 feet of the creature and the ally isn't incapacitated. 
 
 ### Actions    
 **Bite.** _Melee Weapon Attack:_ +5 to hit, reach 5 ft., one target. _Hit:_ 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone. 


### PR DESCRIPTION
"Keen Hearing and Smell" and "Pack Tactics" were on the same line, just splitting them out.