### PR TITLE
Add Thorn Whip to list of druid cantrips

### DIFF
--- a/docs/spellcasting/spells/thorn_whip.md
+++ b/docs/spellcasting/spells/thorn_whip.md
@@ -1,0 +1,16 @@
+name: Thorn Whip
+level: 0
+school: transmutation
+classes: druid
+
+# Thorn Whip 
+_Transmutation cantrip_
+
+**Casting Time:** 1 action
+**Range:** 30 feet
+**Components:** V, S, M (the stem of a plant with thorns)
+**Duration:** Instantaneous
+
+You create a long, vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes 1d6 piercing damage, and if the creature is Large or smaller, you pull the creature up to 10 feet closer to you.
+
+This spell's damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6).


### PR DESCRIPTION
Hey, thanks for this super useful resource -- it's extremely helpful to have the spells organized like this.

Noticed a small omission so thought I'd pay it forward and add it -- this adds a druid cantrip, `Thorn Whip`, to the list of available cantrips. I hope. Let me know if I can adjust it or if I need to run any of the scripts and check that output in. 