### PR TITLE
Create class spell list index directory if not exists

### DIFF
--- a/build_indexes.py
+++ b/build_indexes.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from srd_index_builder import SRDIndexBuilder
 import logging
 import argparse

--- a/srd_index_builder.py
+++ b/srd_index_builder.py
@@ -53,6 +53,9 @@ class SRDIndexBuilder:
 
         # After building the indexes, also build the class spell lists if requested
         if build_config['class_spell_lists']:
+            if not os.path.exists(build_config['class_spell_lists']['index_path']):
+                os.makedirs(build_config['class_spell_lists']['index_path'])
+
             self.build_class_spell_lists(build_config['indexes']['spells'], build_config['class_spell_lists'])
 
     def _clean_index_directory(self, directory):


### PR DESCRIPTION
When I checked out 5thSRD for the first time and followed the instructions in README.md to get set up, I got an error because the index builder attempted to write to the class spell lists index directory without creating it first. This PR creates that directory first so that the README.md instructions are easier to follow.