### PR TITLE
Theme color

### DIFF
--- a/5thsrd_theme/css/variables.less
+++ b/5thsrd_theme/css/variables.less
@@ -6,7 +6,7 @@
 @gray: lighten(@gray-base, 33.5%);
 @gray-light: lighten(@gray-base, 46.7%);
 @gray-lighter: lighten(@gray-base, 93.5%);
-@brand-primary: rgb(216, 25, 33);
+@brand-primary: rgb(216, 25, 33); /* Match to mkdocs.yml theme.color */
 @brand-success: rgb(92, 184, 92);
 @brand-info: rgb(91, 192, 222);
 @brand-warning: rgb(240, 173, 78);

--- a/5thsrd_theme/main.html
+++ b/5thsrd_theme/main.html
@@ -11,7 +11,7 @@
         {% if page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
         <link rel="shortcut icon" href="{{ base_url }}/img/favicon.ico">
 
-	<title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
+        <title>{% if page.title %}{{ page.title }} - {% endif %}{{ config.site_name }}</title>
 
         <link href="{{ base_url }}/css/bootstrap-custom.min.css?v={{version_id}}" rel="stylesheet">
         <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">

--- a/5thsrd_theme/main.html
+++ b/5thsrd_theme/main.html
@@ -5,6 +5,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        {% if config.theme.color %}<meta name="theme-color" content="{{ config.theme.color }}">{% endif %}
         {% if config.site_description %}<meta name="description" content="{{ config.site_description }}">{% endif %}
         {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
         {% if page.canonical_url %}<link rel="canonical" href="{{ page.canonical_url }}">{% endif %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_description: A web-based version of the 5th Edition SRD (System Reference D
 google_analytics: ["UA-72655850-1", '5thsrd.org']
 theme:
   name: null
+  color: "rgb(216, 25, 33)" # Match with @brand-primary in variables.less
   custom_dir: 5thsrd_theme
 plugins: []
 extra:


### PR DESCRIPTION
Set the URL bar color to match the red 5thSRD brand color.

So that you can tell what this change looks like and how some other sites use theme-color, I've taken some screenshots. The difference between Google Chrome on Android and Samsung Internet on Android is that Chrome shows a shadow below the URL bar before the page is scrolled down while Samsung Internet does not show the shadow:
https://photos.app.goo.gl/TNjDZcbTZHm74v2M9