### PR TITLE
Bane Spell Text Format Fix

### DIFF
--- a/docs/spellcasting/spells/bane.md
+++ b/docs/spellcasting/spells/bane.md
@@ -11,6 +11,7 @@ _1st-level enchantment_
 **Range:** 30 feet   
 **Components:** V, S, M (a drop of blood)   
 **Duration:** Concentration, up to 1 minute 
+
 Up to three creatures of your choice that you can see within range must make Charisma saving throws. Whenever a target that fails this saving throw makes an attack roll or a saving throw before the spell ends, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw. 
 
 **At Higher Levels.** When you cast this spell using a spell slot of 2nd level or higher, you can target one additional creature for each slot level above 1st. 


### PR DESCRIPTION
The description was mixed with duration in the previous format.
I think what we need is an extra new line.