### PR TITLE
Doppelganger correction

### DIFF
--- a/docs/gamemaster_rules/monsters/doppelganger.md
+++ b/docs/gamemaster_rules/monsters/doppelganger.md
@@ -20,7 +20,8 @@ _Medium monstrosity (shapechanger), neutral_
 **Challenge** 3 (700 XP) 
 
 **Shapechanger.** The doppelganger can use its action to polymorph into a Small or Medium humanoid it has seen, or back into its true form. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies.    
-**Ambusher.** The doppelganger has advantage on attack rolls against any creature it has surprised. Surprise Attack. If the doppelganger surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 10 (3d6) damage from the attack. 
+**Ambusher.** The doppelganger has advantage on attack rolls against any creature it has surprised. 
+**Surprise Attack.** If the doppelganger surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 10 (3d6) damage from the attack. 
 
 ### Actions 
 **Multiattack.** The doppelganger makes two melee attacks.   

--- a/docs/gamemaster_rules/monsters/ettercap.md
+++ b/docs/gamemaster_rules/monsters/ettercap.md
@@ -18,7 +18,8 @@ _Medium monstrosity, neutral evil_
 **Languages** --    
 **Challenge** 2 (450 XP) 
 
-**Spider Climb.** The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check. Web Sense. While in contact with a web, the ettercap knows the exact location of any other creature in contact with the same web.    
+**Spider Climb.** The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check. 
+**Web Sense.** While in contact with a web, the ettercap knows the exact location of any other creature in contact with the same web.    
 **Web Walker.** The ettercap ignores movement restrictions caused by webbing. 
 
 ### Actions 

--- a/docs/gamemaster_rules/monsters/giant_wolf_spider.md
+++ b/docs/gamemaster_rules/monsters/giant_wolf_spider.md
@@ -18,7 +18,8 @@ _Medium beast, unaligned_
 **Languages** --    
 **Challenge** 1/4 (50 XP) 
 
-**Spider Climb.** The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check. Web Sense. While in contact with a web, the spider knows the exact location of any other creature in contact with the same web.    
+**Spider Climb.** The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check. 
+**Web Sense.** While in contact with a web, the spider knows the exact location of any other creature in contact with the same web.    
 **Web Walker.** The spider ignores movement restrictions caused by webbing. 
 
 ### Actions    

--- a/docs/gamemaster_rules/monsters/weretiger.md
+++ b/docs/gamemaster_rules/monsters/weretiger.md
@@ -27,4 +27,5 @@ _Medium humanoid (human, shapechanger), neutral_
 **Multiattack (Humanoid or Hybrid Form Only).** In humanoid form, the weretiger makes two scimitar attacks or two longbow attacks. In hybrid form, it can attack like a humanoid or make two claw attacks.    
 **Bite (Tiger or Hybrid Form Only).** _Melee Weapon Attack:_ +5 to hit, reach 5 ft., one target. _Hit:_ 8 (1d10 + 3) piercing damage. If the target is a humanoid, it must succeed on a DC 13 Constitution saving throw or be cursed with weretiger lycanthropy.    
 **Claw (Tiger or Hybrid Form Only).** _Melee Weapon Attack:_ +5 to hit, reach 5 ft., one target. _Hit:_ 7 (1d8 + 3) slashing damage.    
-**Scimitar (Humanoid or Hybrid Form Only).** _Melee Weapon Attack:_ +5 to hit, reach 5 ft., one target. _Hit:_ 6 (1d6 + 3) slashing damage. Longbow (Humanoid or Hybrid Form Only). _Ranged Weapon Attack:_ +4 to hit, range 150/600 ft., one target. _Hit:_ 6 (1d8 + 2) piercing damage.
+**Scimitar (Humanoid or Hybrid Form Only).** _Melee Weapon Attack:_ +5 to hit, reach 5 ft., one target. _Hit:_ 6 (1d6 + 3) slashing damage. 
+**Longbow (Humanoid or Hybrid Form Only).** _Ranged Weapon Attack:_ +4 to hit, range 150/600 ft., one target. _Hit:_ 6 (1d8 + 2) piercing damage.


### PR DESCRIPTION
The Surprise Attack ability of the Doppelganger is incorrectly included in the Ambusher ability before.